### PR TITLE
Remove Profile fields other than name

### DIFF
--- a/edxval/admin.py
+++ b/edxval/admin.py
@@ -7,7 +7,7 @@ from .models import Video, Profile, EncodedVideo, Subtitle, CourseVideo
 
 
 class ProfileAdmin(admin.ModelAdmin):  # pylint: disable=C0111
-    list_display = ('id', 'profile_name', 'extension', 'width', 'height')
+    list_display = ('id', 'profile_name')
     list_display_links = ('id', 'profile_name')
     admin_order_field = 'profile_name'
 

--- a/edxval/migrations/0004_remove_profile_fields.py
+++ b/edxval/migrations/0004_remove_profile_fields.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # The extension, width, and height fields of the Profile model are
+        # removed, but we want this migration to be non-destructive. Thus, the
+        # columns are simply altered to allow null values.
+        db.alter_column('edxval_profile', 'width', self.gf('django.db.models.fields.PositiveIntegerField')(null=True, default=1))
+        db.alter_column('edxval_profile', 'extension', self.gf('django.db.models.fields.CharField')(max_length=10, null=True, default='mp4'))
+        db.alter_column('edxval_profile', 'height', self.gf('django.db.models.fields.PositiveIntegerField')(null=True, default=1))
+
+        # On MySQL, attempts to insert new model instances (which lack values
+        # for the removed fields) results in a warning about a lack of a default
+        # value. Because django does not have a mechanism for specifying the
+        # default value in the database, we must manually alter the table here.
+        if db.backend_name == 'mysql':
+            db.execute("ALTER TABLE edxval_profile MODIFY extension VARCHAR(10) DEFAULT 'mp4'")
+            db.execute("ALTER TABLE edxval_profile MODIFY width INT(10) UNSIGNED DEFAULT 1")
+            db.execute("ALTER TABLE edxval_profile MODIFY height INT(10) UNSIGNED DEFAULT 1")
+
+    def backwards(self, orm):
+        # Remove database-level defaults applied above
+        if db.backend_name == 'mysql':
+            db.execute("ALTER TABLE edxval_profile MODIFY extension VARCHAR(10)")
+            db.execute("ALTER TABLE edxval_profile MODIFY width INT(10) UNSIGNED")
+            db.execute("ALTER TABLE edxval_profile MODIFY height INT(10) UNSIGNED")
+
+        # Because the forward migration is non-destructive and simply alters the
+        # extension, width, and height columns of the Profile model to allow
+        # null values, values from before the forward migration will still be
+        # present in the table. The backward migration restores the non-null
+        # restriction to each column and provides dumb defaults for any profiles
+        # that were created between the application of the forward migration and
+        # backward migration.
+        db.alter_column('edxval_profile', 'width', self.gf('django.db.models.fields.PositiveIntegerField')(default=1))
+        db.alter_column('edxval_profile', 'extension', self.gf('django.db.models.fields.CharField')(default='mp4', max_length=10))
+        db.alter_column('edxval_profile', 'height', self.gf('django.db.models.fields.PositiveIntegerField')(default=1))
+
+    models = {
+        'edxval.coursevideo': {
+            'Meta': {'unique_together': "(('course_id', 'video'),)", 'object_name': 'CourseVideo'},
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'video': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'courses'", 'to': "orm['edxval.Video']"})
+        },
+        'edxval.encodedvideo': {
+            'Meta': {'object_name': 'EncodedVideo'},
+            'bitrate': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'file_size': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'profile': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['edxval.Profile']"}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'video': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'encoded_videos'", 'to': "orm['edxval.Video']"})
+        },
+        'edxval.profile': {
+            'Meta': {'object_name': 'Profile'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'profile_name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        'edxval.subtitle': {
+            'Meta': {'object_name': 'Subtitle'},
+            'content': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'fmt': ('django.db.models.fields.CharField', [], {'max_length': '20', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'db_index': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'video': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subtitles'", 'to': "orm['edxval.Video']"})
+        },
+        'edxval.video': {
+            'Meta': {'object_name': 'Video'},
+            'client_video_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'duration': ('django.db.models.fields.FloatField', [], {}),
+            'edx_video_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['edxval']

--- a/edxval/models.py
+++ b/edxval/models.py
@@ -5,26 +5,9 @@ When calling a serializers' .errors field, there is a priority in which the
 errors are returned. This may cause a partial return of errors, starting with
 the highest priority.
 
-Example:
-class Profile(models.Model)
-    profile_name = models.CharField(
-        max_length=50,
-        unique=True,
-        validators=[
-            RegexValidator(
-                regex=regex,
-                message='profile_name has invalid characters',
-                code='invalid profile_name'
-            ),
-        ]
-    )
-    extension = models.CharField(max_length=10)
-    width = models.PositiveIntegerField()
-    height = models.PositiveIntegerField()
-
-Missing a field, having an input type (expected an int, not a str),
+Missing a field, having an incorrect input type (expected an int, not a str),
 nested serialization errors, or any similar errors will be returned by
-themselves. After these are resolved, errors such as a negative height, or
+themselves. After these are resolved, errors such as a negative file_size or
 invalid profile_name will be returned.
 """
 
@@ -54,9 +37,6 @@ class Profile(models.Model):
             ),
         ]
     )
-    extension = models.CharField(max_length=10)
-    width = models.PositiveIntegerField()
-    height = models.PositiveIntegerField()
 
     def __unicode__(self):
         return self.profile_name

--- a/edxval/serializers.py
+++ b/edxval/serializers.py
@@ -10,20 +10,6 @@ from django.core.exceptions import ValidationError
 from edxval.models import Profile, Video, EncodedVideo, Subtitle, CourseVideo
 
 
-class ProfileSerializer(serializers.ModelSerializer):
-    """
-    Serializer for Profile object.
-    """
-    class Meta:  # pylint: disable=C1001, C0111
-        model = Profile
-        fields = (
-            "profile_name",
-            "extension",
-            "width",
-            "height"
-        )
-
-
 class EncodedVideoSerializer(serializers.ModelSerializer):
     """
     Serializer for EncodedVideo object.

--- a/edxval/tests/constants.py
+++ b/edxval/tests/constants.py
@@ -7,24 +7,9 @@ EDX_VIDEO_ID = "itchyjacket"
 """
 Generic Profiles for manually creating profile objects
 """
-PROFILE_DICT_MOBILE = dict(
-    profile_name="mobile",
-    extension="avi",
-    width=100,
-    height=101
-)
-PROFILE_DICT_DESKTOP = dict(
-    profile_name="desktop",
-    extension="mp4",
-    width=200,
-    height=2001
-)
-PROFILE_DICT_YOUTUBE = dict(
-    profile_name="youtube",
-    extension="mp4",
-    width=1280,
-    height=720
-)
+PROFILE_MOBILE = "mobile"
+PROFILE_DESKTOP = "desktop"
+PROFILE_YOUTUBE = "youtube"
 """
 Encoded_videos for test_api, does not have profile.
 """
@@ -112,40 +97,7 @@ VIDEO_DICT_NON_LATIN_ID = dict(
     encoded_videos=[],
     subtitles=[]
 )
-PROFILE_DICT_NON_LATIN = dict(
-    profile_name=u"배고파",
-    extension="mew",
-    width=100,
-    height=300
-)
-PROFILE_DICT_INVALID_NAME = dict(
-    profile_name="lo/lol",
-    extension="mew",
-    width=100,
-    height=300
-)
-PROFILE_DICT_NEGATIVE_WIDTH = dict(
-    profile_name="mobile",
-    extension="mew",
-    width=-100,
-    height=300
-)
-PROFILE_DICT_NEGATIVE_HEIGHT = dict(
-    profile_name="mobile",
-    extension="mew",
-    width=100,
-    height=-300
-)
-PROFILE_DICT_MISSING_EXTENSION = dict(
-    profile_name="mobile",
-    width=100,
-    height=300
-)
-PROFILE_DICT_MANY_INVALID = dict(
-    profile_name="hh/ff",
-    width=-100,
-    height="lol",
-)
+PROFILE_INVALID_NAME = "lo/lol"
 """
 Subtitles
 """

--- a/edxval/tests/test_serializers.py
+++ b/edxval/tests/test_serializers.py
@@ -8,7 +8,6 @@ from django.test import TestCase
 
 from edxval.serializers import (
     EncodedVideoSerializer,
-    ProfileSerializer,
     VideoSerializer,
     ValidationError,
 )
@@ -22,11 +21,14 @@ class SerializerTests(TestCase):
     """
     def setUp(self):
         """
-        Creates Profile objects
+        Creates Profile objects and a video object
         """
-        Profile.objects.create(**constants.PROFILE_DICT_MOBILE)
-        Profile.objects.create(**constants.PROFILE_DICT_DESKTOP)
-        Profile.objects.create(**constants.PROFILE_DICT_NON_LATIN)
+        Profile.objects.create(profile_name=constants.PROFILE_MOBILE)
+        Profile.objects.create(profile_name=constants.PROFILE_DESKTOP)
+        Video.objects.create(
+            duration=0,
+            edx_video_id=constants.VIDEO_DICT_NON_LATIN_ID["edx_video_id"]
+        )
 
     def test_negative_fields_for_encoded_video_serializer(self):
         """
@@ -60,8 +62,10 @@ class SerializerTests(TestCase):
         """
         # TODO not the best test. Need to understand what result we want
         self.assertIsInstance(
-            ProfileSerializer(Profile.objects.get(profile_name="배고파")),
-            ProfileSerializer
+            VideoSerializer(
+                Video.objects.get(edx_video_id=constants.VIDEO_DICT_NON_LATIN_ID["edx_video_id"])
+            ),
+            VideoSerializer
         )
 
     def test_invalid_edx_video_id(self):

--- a/edxval/tests/test_views.py
+++ b/edxval/tests/test_views.py
@@ -18,8 +18,8 @@ class VideoDetail(APIAuthTestCase):
         """
         Used for manually creating profile objects which EncodedVideos require.
         """
-        Profile.objects.create(**constants.PROFILE_DICT_MOBILE)
-        Profile.objects.create(**constants.PROFILE_DICT_DESKTOP)
+        Profile.objects.create(profile_name=constants.PROFILE_MOBILE)
+        Profile.objects.create(profile_name=constants.PROFILE_DESKTOP)
         super(VideoDetail, self).setUp()
 
     # Tests for successful PUT requests.
@@ -321,8 +321,8 @@ class VideoListTest(APIAuthTestCase):
         """
         Used for manually creating profile objects which EncodedVideos require.
         """
-        Profile.objects.create(**constants.PROFILE_DICT_MOBILE)
-        Profile.objects.create(**constants.PROFILE_DICT_DESKTOP)
+        Profile.objects.create(profile_name=constants.PROFILE_MOBILE)
+        Profile.objects.create(profile_name=constants.PROFILE_DESKTOP)
         super(VideoListTest, self).setUp()
 
     def tearDown(self):
@@ -573,8 +573,8 @@ class VideoDetailTest(APIAuthTestCase):
         """
         Used for manually creating profile objects which EncodedVideos require.
         """
-        Profile.objects.create(**constants.PROFILE_DICT_MOBILE)
-        Profile.objects.create(**constants.PROFILE_DICT_DESKTOP)
+        Profile.objects.create(profile_name=constants.PROFILE_MOBILE)
+        Profile.objects.create(profile_name=constants.PROFILE_DESKTOP)
         super(VideoDetailTest, self).setUp()
 
     def test_get_all_videos(self):
@@ -615,8 +615,8 @@ class SubtitleDetailTest(APIAuthTestCase):
     Tests for subtitle API
     """
     def setUp(self):
-        Profile.objects.create(**constants.PROFILE_DICT_MOBILE)
-        Profile.objects.create(**constants.PROFILE_DICT_DESKTOP)
+        Profile.objects.create(profile_name=constants.PROFILE_MOBILE)
+        Profile.objects.create(profile_name=constants.PROFILE_DESKTOP)
         super(SubtitleDetailTest, self).setUp()
 
     def test_get_subtitle_content(self):

--- a/edxval/views.py
+++ b/edxval/views.py
@@ -11,7 +11,6 @@ from django.views.decorators.http import last_modified
 from edxval.models import Video, Profile, Subtitle
 from edxval.serializers import (
     VideoSerializer,
-    ProfileSerializer,
     SubtitleSerializer
 )
 
@@ -75,17 +74,6 @@ class VideoList(generics.ListCreateAPIView):
             # view videos by youtube id
             qset = qset & Video.by_youtube_id(youtube_id)
         return qset
-
-
-class ProfileList(generics.ListCreateAPIView):
-    """
-    GETs or POST video objects
-    """
-    authentication_classes = (OAuth2Authentication, SessionAuthentication)
-    permission_classes = (ReadRestrictedDjangoModelPermissions,)
-    queryset = Profile.objects.all()
-    lookup_field = "profile_name"
-    serializer_class = ProfileSerializer
 
 
 class VideoDetail(generics.RetrieveUpdateDestroyAPIView):


### PR DESCRIPTION
None of the fields except profile_name is ever used at present (we don't
even do any validation that the encoded videos added to VAL match the
profile), and the edX media team prefers that the profiles be somewhat
fungible anyway. The motivation for this change is to avoid the need to
sync profile information between systems when doing export/import of
video modules that use Video IDs.

@BenjiLee @ormsbee please review (and please do actually look at the migration. It has been manually edited.)