### PR TITLE
Add XML export and import API functions

### DIFF
--- a/edxval/serializers.py
+++ b/edxval/serializers.py
@@ -79,8 +79,9 @@ class CourseSerializer(serializers.RelatedField):
 
     def from_native(self, data):
         if data:
-            return CourseVideo(course_id=data)
-
+            course_video = CourseVideo(course_id=data)
+            course_video.full_clean(exclude=["video"])
+            return course_video
 
 class VideoSerializer(serializers.ModelSerializer):
     """

--- a/edxval/tests/test_serializers.py
+++ b/edxval/tests/test_serializers.py
@@ -79,6 +79,22 @@ class SerializerTests(TestCase):
             u"edx_video_id has invalid characters"
         )
 
+    def test_invalid_course_id(self):
+        errors = VideoSerializer(
+            data={
+                "edx_video_id": "dummy",
+                "client_video_id": "dummy",
+                "duration": 0,
+                "status": "dummy",
+                "encoded_videos": [],
+                "courses": ["x" * 300],
+            }
+        ).errors
+        self.assertEqual(
+            errors,
+            {"courses": ["Ensure this value has at most 255 characters (it has 300)."]}
+        )
+
     def test_encoded_video_set_output(self):
         """
         Tests for basic structure of EncodedVideoSetSerializer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 django>=1.4,<1.5
 djangorestframework<2.4
 enum34==1.0.4
+lxml==3.3.6
 South==1.0.1
 -e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-1#egg=django-oauth2-provider


### PR DESCRIPTION
These will be used to support export/import of courses containing video
modules that rely on VAL being populated. This does not allow updating
a video (including adding encodings) via import.

JIRA: MA-110

I created a new branch (and, therefore, PR) to avoid clobbering Nimisha's work.

@nasthagiri @BenjiLee Please review