### PR TITLE
Update Django rest framework

### DIFF
--- a/edxval/serializers.py
+++ b/edxval/serializers.py
@@ -5,7 +5,7 @@ Serialization is usually sent through the VideoSerializer which uses the
 EncodedVideoSerializer which uses the profile_name as it's profile field.
 """
 from rest_framework import serializers
-from django.core.exceptions import ValidationError
+from rest_framework.fields import IntegerField, DateTimeField
 
 from edxval.models import Profile, Video, EncodedVideo, Subtitle, CourseVideo
 
@@ -16,7 +16,20 @@ class EncodedVideoSerializer(serializers.ModelSerializer):
 
     Uses the profile_name as it's profile value instead of a Profile object.
     """
-    profile = serializers.SlugRelatedField(slug_field="profile_name")
+    profile = serializers.SlugRelatedField(
+        slug_field="profile_name",
+        queryset=Profile.objects.all()
+    )
+
+    # Django Rest Framework v3 doesn't enforce minimum values for
+    # PositiveIntegerFields, so we need to specify the min value explicitly.
+    bitrate = IntegerField(min_value=0)
+    file_size = IntegerField(min_value=0)
+
+    # Django Rest Framework v3 converts datetimes to unicode by default.
+    # Specify format=None to leave them as datetimes.
+    created = DateTimeField(required=False, format=None)
+    modified = DateTimeField(required=False, format=None)
 
     class Meta:  # pylint: disable=C1001, C0111
         model = EncodedVideo
@@ -44,20 +57,20 @@ class SubtitleSerializer(serializers.ModelSerializer):
     content_url = serializers.CharField(source='get_absolute_url', read_only=True)
     content = serializers.CharField(write_only=True)
 
-    def validate_content(self, attrs, source):
+    def validate(self, data):
         """
         Validate that the subtitle is in the correct format
         """
-        value = attrs[source]
-        if attrs.get('fmt') == 'sjson':
+        value = data.get("content")
+        if data.get("fmt") == "sjson":
             import json
             try:
                 loaded = json.loads(value)
             except ValueError:
                 raise serializers.ValidationError("Not in JSON format")
             else:
-                attrs[source] = json.dumps(loaded)
-        return attrs
+                data["content"] = json.dumps(loaded)
+        return data
 
     class Meta:  # pylint: disable=C1001, C0111
         model = Subtitle
@@ -74,10 +87,10 @@ class CourseSerializer(serializers.RelatedField):
     """
     Field for CourseVideo
     """
-    def to_native(self, value):
+    def to_representation(self, value):
         return value.course_id
 
-    def from_native(self, data):
+    def to_internal_value(self, data):
         if data:
             course_video = CourseVideo(course_id=data)
             course_video.full_clean(exclude=["video"])
@@ -90,10 +103,19 @@ class VideoSerializer(serializers.ModelSerializer):
 
     encoded_videos takes a list of dicts EncodedVideo data.
     """
-    encoded_videos = EncodedVideoSerializer(many=True, allow_add_remove=True)
-    subtitles = SubtitleSerializer(many=True, allow_add_remove=True, required=False)
-    courses = CourseSerializer(many=True, read_only=False)
-    url = serializers.SerializerMethodField('get_url')
+    encoded_videos = EncodedVideoSerializer(many=True)
+    subtitles = SubtitleSerializer(many=True, required=False)
+    courses = CourseSerializer(
+        many=True,
+        read_only=False,
+        required=False,
+        queryset=CourseVideo.objects.all()
+    )
+    url = serializers.SerializerMethodField()
+
+    # Django Rest Framework v3 converts datetimes to unicode by default.
+    # Specify format=None to leave them as datetimes.
+    created = DateTimeField(required=False, format=None)
 
     class Meta:  # pylint: disable=C1001, C0111
         model = Video
@@ -106,33 +128,80 @@ class VideoSerializer(serializers.ModelSerializer):
         """
         return obj.get_absolute_url()
 
-    def restore_fields(self, data, files):
+    def validate(self, data):
         """
-        Overridden function used to check against duplicate profile names.
-
-        Converts a dictionary of data into a dictionary of deserialized fields. Also
-        checks if there are duplicate profile_name(s). If there is, the deserialization
-        is rejected.
+        Check that the video data is valid.
         """
-        reverted_data = {}
-
         if data is not None and not isinstance(data, dict):
-            self._errors['non_field_errors'] = ['Invalid data']
-            return None
+            raise serializers.ValidationError("Invalid data")
 
         try:
             profiles = [ev["profile"] for ev in data.get("encoded_videos", [])]
             if len(profiles) != len(set(profiles)):
-                self._errors['non_field_errors'] = ['Invalid data: duplicate profiles']
+                raise serializers.ValidationError("Invalid data: duplicate profiles")
         except KeyError:
-            raise ValidationError("profile required for deserializing")
+            raise serializers.ValidationError("profile required for deserializing")
         except TypeError:
-            raise ValidationError("profile field needs to be a profile_name (str)")
+            raise serializers.ValidationError("profile field needs to be a profile_name (str)")
 
-        for field_name, field in self.fields.items():
-            field.initialize(parent=self, field_name=field_name)
-            try:
-                field.field_from_native(data, files, field_name, reverted_data)
-            except ValidationError as err:
-                self._errors[field_name] = list(err.messages)
-        return reverted_data
+        return data
+
+    def create(self, validated_data):
+        """
+        Create the video and its nested resources.
+        """
+        courses = validated_data.pop("courses", [])
+        encoded_videos = validated_data.pop("encoded_videos", [])
+        subtitles = validated_data.pop("subtitles", [])
+
+        video = Video.objects.create(**validated_data)
+
+        EncodedVideo.objects.bulk_create(
+            EncodedVideo(video=video, **video_data)
+            for video_data in encoded_videos
+        )
+
+        Subtitle.objects.bulk_create(
+            Subtitle(video=video, **subtitle_data)
+            for subtitle_data in subtitles
+        )
+
+        # The CourseSerializer will already have converted the course data
+        # to CourseVideo models, so we can just set the video and save.
+        for course_video in courses:
+            course_video.video = video
+            course_video.save()
+
+        return video
+
+    def update(self, instance, validated_data):
+        """
+        Update an existing video resource.
+        """
+        instance.status = validated_data["status"]
+        instance.client_video_id = validated_data["client_video_id"]
+        instance.duration = validated_data["duration"]
+        instance.save()
+
+        # Set encoded videos
+        instance.encoded_videos.all().delete()
+        EncodedVideo.objects.bulk_create(
+            EncodedVideo(video=instance, **video_data)
+            for video_data in validated_data.get("encoded_videos", [])
+        )
+
+        # Set subtitles
+        instance.subtitles.all().delete()
+        Subtitle.objects.bulk_create(
+            Subtitle(video=instance, **subtitle_data)
+            for subtitle_data in validated_data.get("subtitles", [])
+        )
+
+        # Set courses
+        # NOTE: for backwards compatibility with the DRF v2 behavior,
+        # we do NOT delete existing course videos during the update.
+        for course_video in validated_data.get("courses", []):
+            course_video.video = instance
+            course_video.save()
+
+        return instance

--- a/edxval/tests/test_views.py
+++ b/edxval/tests/test_views.py
@@ -486,7 +486,7 @@ class VideoListTest(APIAuthTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.data.get("edx_video_id")[0],
-            "Video with this Edx video id already exists."
+            "This field must be unique."
         )
         videos = len(self.client.get("/edxval/videos/").data)
         self.assertEqual(videos, 1)
@@ -641,7 +641,7 @@ class VideoListTest(APIAuthTestCase):
         Tests number of queries for a Video/EncodedVideo(2) pair
         """
         url = reverse('video-list')
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(17):
             self.client.post(url, constants.COMPLETE_SET_FISH, format='json')
 
     def test_queries_for_single_encoded_videos(self):
@@ -649,7 +649,7 @@ class VideoListTest(APIAuthTestCase):
         Tests number of queries for a Video/EncodedVideo(1) pair
                 """
         url = reverse('video-list')
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(14):
             self.client.post(url, constants.COMPLETE_SET_STAR, format='json')
 
 

--- a/edxval/views.py
+++ b/edxval/views.py
@@ -2,7 +2,8 @@
 Views file for django app edxval.
 """
 from rest_framework import generics
-from rest_framework.authentication import OAuth2Authentication, SessionAuthentication
+from rest_framework.authentication import SessionAuthentication
+from rest_framework_oauth.authentication import OAuth2Authentication
 from rest_framework.permissions import DjangoModelPermissions
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 django>=1.4,<1.5
-djangorestframework<2.4
+djangorestframework>=3.1,<3.2
 enum34==1.0.4
 lxml==3.3.6
 South==1.0.1
--e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-1#egg=django-oauth2-provider
+-e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-5#egg=django-oauth2-provider
+-e git+https://github.com/edx/django-rest-framework-oauth.git@f0b503fda8c254a38f97fef802ded4f5fe367f7a#egg=djangorestframework-oauth

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edxval',
-    version='0.0.5',
+    version='0.0.6',
     author='edX',
     url='http://github.com/edx/edx-val',
     description='edx-val',


### PR DESCRIPTION
* Upgrade Django Rest Framework to version 3.1
* Add an external library for OAuth authentication (moved out of DRF core)
* Add a test case for updating course IDs associated with a video.

Part of the Django 1.8 upgrade work.  This introduces one change to the API: previously, when PUTing a video, `courses` and `encoded_videos` not specified in the data would not be deleted.  This may or may not be a bug in the current implementation -- if it's not, I'll need to update the test case I added and fix the code.