### PR TITLE
Jibsheet/dont use using

### DIFF
--- a/edxval/migrations/0002_data__default_profiles.py
+++ b/edxval/migrations/0002_data__default_profiles.py
@@ -16,16 +16,14 @@ DEFAULT_PROFILES = [
 def create_default_profiles(apps, schema_editor):
     """ Add default profiles """
     Profile = apps.get_model("edxval", "Profile")
-    db_alias = schema_editor.connection.alias
     for profile in DEFAULT_PROFILES:
-        Profile.objects.using(db_alias).get_or_create(profile_name=profile)
+        Profile.objects.get_or_create(profile_name=profile)
 
 
 def delete_default_profiles(apps, schema_editor):
     """ Remove default profiles """
     Profile = apps.get_model("edxval", "Profile")
-    db_alias = schema_editor.connection.alias
-    Profile.objects.using(db_alias).filter(profile_name__in=DEFAULT_PROFILES).delete()
+    Profile.objects.filter(profile_name__in=DEFAULT_PROFILES).delete()
 
 
 class Migration(migrations.Migration):

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edxval',
-    version='0.0.8',
+    version='0.0.9',
     author='edX',
     url='http://github.com/edx/edx-val',
     description='edx-val',


### PR DESCRIPTION
Having a using() in a migration prevents causes errors when running edx-platform with two backing databases (it forces the migration to try and create/read tables in the wrong database).  Removing the using allows Django to use the internal DB router to find the right location.

I reversed and re-ran this migration in a devstack without issue and checked that since we're updating an already-run migration we won't be impacting future deploys.

I'm also bumping the version so we can update what platform includes in my platform PR.

@BenjiLee 
@edx/devops 