### PR TITLE
Updating enum43 to support Python3 versions

### DIFF
--- a/edxval/models.py
+++ b/edxval/models.py
@@ -22,6 +22,7 @@ from django.dispatch import receiver
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator, RegexValidator
 from django.core.urlresolvers import reverse
+from django.utils.six import python_2_unicode_compatible
 
 from model_utils.models import TimeStampedModel
 
@@ -60,6 +61,7 @@ class ModelFactoryWithValidation(object):
             return cls.create_with_validation(*args, **kwargs), True
 
 
+@python_2_unicode_compatible
 class Profile(models.Model):
     """
     Details for pre-defined encoding format
@@ -79,7 +81,7 @@ class Profile(models.Model):
         ]
     )
 
-    def __unicode__(self):
+    def __str__(self):
         return self.profile_name
 
 
@@ -131,6 +133,7 @@ class Video(models.Model):
         return qset
 
 
+@python_2_unicode_compatible
 class CourseVideo(models.Model, ModelFactoryWithValidation):
     """
     Model for the course_id associated with the video content.
@@ -155,7 +158,7 @@ class CourseVideo(models.Model, ModelFactoryWithValidation):
         if hasattr(self, 'video_image'):
             return self.video_image.image_url()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.course_id
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pillow==4.2.1
 boto==2.46.1
 django-model-utils==2.3.1
 django-storages==1.5.2
-enum34==1.0.4
+enum34==1.1.6
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 lxml==3.3.6


### PR DESCRIPTION
This will save us from the following error

```PYTHON
    AttributeError: module 'enum' has no attribute 'IntFlag'
```