### PR TITLE
Fully supporting Python 2 and Python 3 in this repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - '2.7'
+- '3.6'
 env:
 - TOXENV=django18
 - TOXENV=django110

--- a/README.md
+++ b/README.md
@@ -10,21 +10,21 @@ Retrieve all profiles for a video with `edx_video_id`="example"
 Returns (dict):
 {
     'url' : '/edxval/videos/example',
-    'edx_video_id': u'example',
+    'edx_video_id': 'example',
     'duration': 111.0,
-    'client_video_id': u'The example video',
+    'client_video_id': 'The example video',
     'encoded_videos': [
         {
-            'url': u'http://www.example.com/example_mobile_video.mp4',
+            'url': 'http://www.example.com/example_mobile_video.mp4',
             'file_size': 25556,
             'bitrate': 9600,
-            'profile': u'mobile'
+            'profile': 'mobile'
         },
         {
-            'url': u'http://www.example.com/example_desktop_video.mp4',
+            'url': 'http://www.example.com/example_desktop_video.mp4',
             'file_size': 43096734,
             'bitrate': 64000,
-            'profile': u'desktop'
+            'profile': 'desktop'
         }
     ]
 }

--- a/edxval/admin.py
+++ b/edxval/admin.py
@@ -1,6 +1,7 @@
 """
 Admin file for django app edxval.
 """
+from __future__ import unicode_literals
 from django.contrib import admin
 
 from .models import (CourseVideo, EncodedVideo, Profile, TranscriptPreference,

--- a/edxval/api.py
+++ b/edxval/api.py
@@ -891,7 +891,7 @@ def import_from_xml(xml, edx_video_id, course_id=None):
 
         return
     except ValidationError as err:
-        logger.exception(err.message)
+        logger.exception(err)
         raise ValCannotCreateError(err.message_dict)
     except Video.DoesNotExist:
         pass

--- a/edxval/api.py
+++ b/edxval/api.py
@@ -3,6 +3,7 @@
 """
 The internal API for VAL.
 """
+from __future__ import unicode_literals
 import logging
 from enum import Enum
 
@@ -10,14 +11,26 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from lxml import etree
 from lxml.etree import Element, SubElement
 
-from edxval.exceptions import (InvalidTranscriptFormat,
-                               InvalidTranscriptProvider, ValCannotCreateError,
-                               ValCannotUpdateError, ValInternalError,
-                               ValVideoNotFoundError)
-from edxval.models import (CourseVideo, EncodedVideo, Profile,
-                           TranscriptFormat, TranscriptPreference,
-                           TranscriptProviderType, Video, VideoImage,
-                           VideoTranscript, ThirdPartyTranscriptCredentialsState)
+from edxval.exceptions import (
+    InvalidTranscriptFormat,
+    InvalidTranscriptProvider,
+    ValCannotCreateError,
+    ValCannotUpdateError,
+    ValInternalError,
+    ValVideoNotFoundError,
+)
+from edxval.models import (
+    CourseVideo,
+    EncodedVideo,
+    Profile,
+    TranscriptFormat,
+    TranscriptPreference,
+    TranscriptProviderType,
+    Video,
+    VideoImage,
+    VideoTranscript,
+    ThirdPartyTranscriptCredentialsState,
+)
 from edxval.serializers import TranscriptPreferenceSerializer, TranscriptSerializer, VideoSerializer
 from edxval.utils import THIRD_PARTY_TRANSCRIPTION_PLANS
 
@@ -423,7 +436,7 @@ def update_video_image(edx_video_id, course_id, image_data, file_name):
             course_id=course_id, video__edx_video_id=edx_video_id
         )
     except ObjectDoesNotExist:
-        error_message = u'VAL: CourseVideo not found for edx_video_id: {0} and course_id: {1}'.format(
+        error_message = 'VAL: CourseVideo not found for edx_video_id: {0} and course_id: {1}'.format(
             edx_video_id,
             course_id
         )
@@ -503,15 +516,15 @@ def get_video_info(edx_video_id):
         Returns (dict):
         {
             'url' : '/edxval/videos/example',
-            'edx_video_id': u'example',
+            'edx_video_id': 'example',
             'duration': 111.0,
-            'client_video_id': u'The example video',
+            'client_video_id': 'The example video',
             'encoded_videos': [
                 {
-                    'url': u'http://www.example.com',
+                    'url': 'http://www.example.com',
                     'file_size': 25556,
                     'bitrate': 9600,
-                    'profile': u'mobile'
+                    'profile': 'mobile'
                  }
             ]
         }
@@ -590,7 +603,7 @@ def get_videos_for_course(course_id, sort_field=None, sort_dir=SortDirection.asc
         total order.
     """
     return _get_videos_for_filter(
-        {'courses__course_id': unicode(course_id), 'courses__is_hidden': False},
+        {'courses__course_id': course_id, 'courses__is_hidden': False},
         sort_field,
         sort_dir,
     )
@@ -658,28 +671,28 @@ def get_video_info_for_course_and_profiles(course_id, profiles):
     Example:
         Given two videos with two profiles each in course_id 'test_course':
         {
-            u'edx_video_id_1': {
-                u'duration: 1111,
-                u'profiles': {
-                    u'mobile': {
-                        'url': u'http: //www.example.com/meow',
+            'edx_video_id_1': {
+                'duration: 1111,
+                'profiles': {
+                    'mobile': {
+                        'url': 'http: //www.example.com/meow',
                         'file_size': 2222
                     },
-                    u'desktop': {
-                        'url': u'http: //www.example.com/woof',
+                    'desktop': {
+                        'url': 'http: //www.example.com/woof',
                         'file_size': 4444
                     }
                 }
             },
-            u'edx_video_id_2': {
-                u'duration: 2222,
-                u'profiles': {
-                    u'mobile': {
-                        'url': u'http: //www.example.com/roar',
+            'edx_video_id_2': {
+                'duration: 2222,
+                'profiles': {
+                    'mobile': {
+                        'url': 'http: //www.example.com/roar',
                         'file_size': 6666
                     },
-                    u'desktop': {
-                        'url': u'http: //www.example.com/bzzz',
+                    'desktop': {
+                        'url': 'http: //www.example.com/bzzz',
                         'file_size': 8888
                     }
                 }
@@ -687,7 +700,6 @@ def get_video_info_for_course_and_profiles(course_id, profiles):
         }
     """
     # In case someone passes in a key (VAL doesn't really understand opaque keys)
-    course_id = unicode(course_id)
     try:
         encoded_videos = EncodedVideo.objects.filter(
             profile__profile_name__in=profiles,
@@ -729,7 +741,7 @@ def copy_course_videos(source_course_id, destination_course_id):
         return
 
     course_videos = CourseVideo.objects.select_related('video', 'video_image').filter(
-        course_id=unicode(source_course_id)
+        course_id=str(source_course_id)
     )
 
     for course_video in course_videos:
@@ -785,7 +797,7 @@ def export_to_xml(video_ids, course_id=None, external=False):
         'video_asset',
         attrib={
             'client_video_id': video.client_video_id,
-            'duration': unicode(video.duration),
+            'duration': str(video.duration),
             'image': video_image_name
         }
     )
@@ -794,7 +806,7 @@ def export_to_xml(video_ids, course_id=None, external=False):
             video_el,
             'encoded_video',
             {
-                name: unicode(getattr(encoded_video, name))
+                name: str(getattr(encoded_video, name))
                 for name in ['profile', 'url', 'file_size', 'bitrate']
             }
         )

--- a/edxval/exceptions.py
+++ b/edxval/exceptions.py
@@ -1,6 +1,8 @@
 """
 VAL Exceptions.
 """
+from __future__ import unicode_literals
+
 
 class ValError(Exception):
     """

--- a/edxval/migrations/0001_initial.py
+++ b/edxval/migrations/0001_initial.py
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
             name='Profile',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('profile_name', models.CharField(unique=True, max_length=50, validators=[django.core.validators.RegexValidator(regex=b'^[a-zA-Z0-9\\-_]*$', message=b'profile_name has invalid characters', code=b'invalid profile_name')])),
+                ('profile_name', models.CharField(unique=True, max_length=50, validators=[django.core.validators.RegexValidator(regex='^[a-zA-Z0-9\\-_]*$', message=b'profile_name has invalid characters', code=b'invalid profile_name')])),
             ],
         ),
         migrations.CreateModel(
@@ -54,7 +54,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created', models.DateTimeField(auto_now_add=True)),
-                ('edx_video_id', models.CharField(unique=True, max_length=100, validators=[django.core.validators.RegexValidator(regex=b'^[a-zA-Z0-9\\-_]*$', message=b'edx_video_id has invalid characters', code=b'invalid edx_video_id')])),
+                ('edx_video_id', models.CharField(unique=True, max_length=100, validators=[django.core.validators.RegexValidator(regex='^[a-zA-Z0-9\\-_]*$', message=b'edx_video_id has invalid characters', code=b'invalid edx_video_id')])),
                 ('client_video_id', models.CharField(db_index=True, max_length=255, blank=True)),
                 ('duration', models.FloatField(validators=[django.core.validators.MinValueValidator(0)])),
                 ('status', models.CharField(max_length=255, db_index=True)),

--- a/edxval/models.py
+++ b/edxval/models.py
@@ -22,8 +22,8 @@ from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.core.validators import MinValueValidator, RegexValidator
 from django.db import models
-from django.dispatch import receiver
-from django.utils.six import python_2_unicode_compatible
+from django.dispatch import receiverfrom django.utils.six import python_2_unicode_compatible
+, string_types
 from model_utils.models import TimeStampedModel
 
 from edxval.utils import (get_video_image_storage,
@@ -268,7 +268,7 @@ class ListField(models.TextField):
         if len(value) > self.max_items:
             raise ValidationError('list must not contain more than {max_items} items.'.format(max_items=self.max_items))
 
-        if all(isinstance(item, basestring) for item in value) is False:
+        if all(isinstance(item, string_types) for item in value) is False:
             raise ValidationError('list must only contain strings.')
 
         return value

--- a/edxval/models.py
+++ b/edxval/models.py
@@ -11,6 +11,7 @@ themselves. After these are resolved, errors such as a negative file_size or
 invalid profile_name will be returned.
 """
 
+from __future__ import unicode_literals
 import json
 import logging
 import os
@@ -219,7 +220,7 @@ class ListField(models.TextField):
         Converts a list to its json representation to store in database as text.
         """
         if value and not isinstance(value, list):
-            raise ValidationError(u'ListField value {} is not a list.'.format(value))
+            raise ValidationError('ListField value {} is not a list.'.format(value))
         return json.dumps(self.validate_list(value) or [])
 
     def from_db_value(self, value, expression, connection, context):
@@ -247,7 +248,7 @@ class ListField(models.TextField):
 
                 self.validate_list(py_list)
             except (ValueError, TypeError):
-                raise ValidationError(u'Must be a valid list of strings.')
+                raise ValidationError('Must be a valid list of strings.')
 
         return py_list
 
@@ -265,12 +266,10 @@ class ListField(models.TextField):
             ValidationError
         """
         if len(value) > self.max_items:
-            raise ValidationError(
-                u'list must not contain more than {max_items} items.'.format(max_items=self.max_items)
-            )
+            raise ValidationError('list must not contain more than {max_items} items.'.format(max_items=self.max_items))
 
         if all(isinstance(item, basestring) for item in value) is False:
-            raise ValidationError(u'list must only contain strings.')
+            raise ValidationError('list must only contain strings.')
 
         return value
 

--- a/edxval/models.py
+++ b/edxval/models.py
@@ -22,8 +22,8 @@ from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.core.validators import MinValueValidator, RegexValidator
 from django.db import models
-from django.dispatch import receiverfrom django.utils.six import python_2_unicode_compatible
-, string_types
+from django.dispatch import receiver
+from django.utils.six import python_2_unicode_compatible, string_types
 from model_utils.models import TimeStampedModel
 
 from edxval.utils import (get_video_image_storage,

--- a/edxval/serializers.py
+++ b/edxval/serializers.py
@@ -4,6 +4,7 @@ Serializers for Video Abstraction Layer
 Serialization is usually sent through the VideoSerializer which uses the
 EncodedVideoSerializer which uses the profile_name as it's profile field.
 """
+from __future__ import unicode_literals
 from rest_framework import serializers
 from rest_framework.fields import DateTimeField, IntegerField
 

--- a/edxval/settings.py
+++ b/edxval/settings.py
@@ -1,6 +1,8 @@
 """
 Settings file for django app edxval.
 """
+from __future__ import unicode_literals
+
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG

--- a/edxval/tests/constants.py
+++ b/edxval/tests/constants.py
@@ -1,5 +1,7 @@
  # pylint: disable=E1103, W0105
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 """
 Constants used for tests.
 """

--- a/edxval/tests/test_api.py
+++ b/edxval/tests/test_api.py
@@ -2,6 +2,7 @@
 """
 Tests for the API for Video Abstraction Layer
 """
+from __future__ import unicode_literals
 import json
 
 import mock
@@ -215,7 +216,7 @@ class CreateProfileTest(TestCase):
         """
         api.create_profile(constants.PROFILE_DESKTOP)
         profiles = list(Profile.objects.all())
-        profile_names = [unicode(profile) for profile in profiles]
+        profile_names = [str(profile) for profile in profiles]
         self.assertEqual(len(profiles), 7)
         self.assertIn(
             constants.PROFILE_DESKTOP,
@@ -290,12 +291,12 @@ class GetVideoInfoTest(TestCase):
         with self.assertRaises(api.ValVideoNotFoundError):
             api.get_video_info("")
 
-    def test_unicode_input(self):
+    def test_str_input(self):
         """
         Tests if unicode inputs are handled correctly
         """
         with self.assertRaises(api.ValVideoNotFoundError):
-            api.get_video_info(u"๓ﻉѻฝ๓ٱซ")
+            api.get_video_info("๓ﻉѻฝ๓ٱซ")
 
     @mock.patch.object(Video, '__init__')
     def test_force_database_error(self, mock_get):
@@ -353,9 +354,9 @@ class GetUrlsForProfileTest(TestCase):
         edx_video_id = constants.VIDEO_DICT_FISH['edx_video_id']
         urls = api.get_urls_for_profiles(edx_video_id, profiles)
         self.assertEqual(len(urls), 3)
-        self.assertEqual(urls["mobile"], u'http://www.meowmix.com')
-        self.assertEqual(urls["desktop"], u'http://www.meowmagic.com')
-        self.assertEqual(urls["hls"], u'https://www.tmnt.com/tmnt101.m3u8')
+        self.assertEqual(urls["mobile"], 'http://www.meowmix.com')
+        self.assertEqual(urls["desktop"], 'http://www.meowmagic.com')
+        self.assertEqual(urls["hls"], 'https://www.tmnt.com/tmnt101.m3u8')
 
     def test_get_urls_for_profiles_no_video(self):
         """
@@ -382,7 +383,7 @@ class GetUrlsForProfileTest(TestCase):
         profile = "mobile"
         edx_video_id = constants.VIDEO_DICT_FISH['edx_video_id']
         url = api.get_url_for_profile(edx_video_id, profile)
-        self.assertEqual(url, u'http://www.meowmix.com')
+        self.assertEqual(url, 'http://www.meowmix.com')
 
 
 class GetVideoForCourseProfiles(TestCase):
@@ -1048,7 +1049,7 @@ class ImportTest(TestCase):
         import_xml = etree.Element(
             "video_asset",
             attrib={
-                key: unicode(video_dict[key])
+                key: str(video_dict[key])
                 for key in ["client_video_id", "duration"]
             }
         )
@@ -1061,7 +1062,7 @@ class ImportTest(TestCase):
                 import_xml,
                 "encoded_video",
                 attrib={
-                    key: unicode(val)
+                    key: str(val)
                     for key, val in encoding_dict.items()
                 }
             )
@@ -1536,7 +1537,7 @@ class CourseVideoImageTest(TestCase):
 
         self.assertEqual(
             get_exception.exception.message,
-            u'VAL: CourseVideo not found for edx_video_id: {0} and course_id: {1}'.format(
+            'VAL: CourseVideo not found for edx_video_id: {0} and course_id: {1}'.format(
                 self.edx_video_id,
                 does_not_course_id
             )
@@ -1573,7 +1574,7 @@ class CourseVideoImageTest(TestCase):
 
         self.assertEqual(
             set_exception.exception.message,
-            u'list must not contain more than {} items.'.format(LIST_MAX_ITEMS)
+            'list must not contain more than {} items.'.format(LIST_MAX_ITEMS)
         )
 
         # expect a validation error if we try to a list with non-string items
@@ -1581,7 +1582,7 @@ class CourseVideoImageTest(TestCase):
             video_image.generated_images = ['a', 1, 2]
             video_image.save()
 
-        self.assertEqual(set_exception.exception.message, u'list must only contain strings.')
+        self.assertEqual(set_exception.exception.message, 'list must only contain strings.')
 
         # expect a validation error if we try to set non list data
         for item in ('a string', 555, {'a': 1}, (1,)):
@@ -1638,7 +1639,7 @@ class CourseVideoImageTest(TestCase):
         with self.assertRaises(IOError) as file_open_exception:
             ImageFile(open(existing_image_name))
 
-        self.assertEqual(file_open_exception.exception.strerror, u'No such file or directory')
+        self.assertEqual(file_open_exception.exception.strerror, 'No such file or directory')
 
     def test_video_image_deletion_multiple(self):
         """

--- a/edxval/tests/test_serializers.py
+++ b/edxval/tests/test_serializers.py
@@ -4,6 +4,7 @@
 Tests the serializers for the Video Abstraction Layer
 """
 
+from __future__ import unicode_literals
 from django.test import TestCase
 
 from edxval.serializers import EncodedVideoSerializer, VideoSerializer
@@ -152,7 +153,9 @@ class SerializerTests(TestCase):
         data = "hello"
         serializer = VideoSerializer(data=data)
         self.assertFalse(serializer.is_valid())
+
+        data_type = type(data).__name__
         self.assertEqual(
             serializer.errors.get("non_field_errors")[0],
-            "Invalid data. Expected a dictionary, but got str."
+            "Invalid data. Expected a dictionary, but got {}.".format(data_type)
         )

--- a/edxval/tests/test_views.py
+++ b/edxval/tests/test_views.py
@@ -777,7 +777,7 @@ class VideoImagesViewTest(APIAuthTestCase):
         },
         {
             'post_data': {'course_id': 'test_course_id', 'edx_video_id': 'super-soaker', 'generated_images': [1, 2, 3]},
-            'message': "[u'list must only contain strings.']"
+            'message': "'list must only contain strings.'"
         },
     )
     @unpack
@@ -789,9 +789,9 @@ class VideoImagesViewTest(APIAuthTestCase):
 
         response = self.client.post(url, post_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            response.data['message'],
-            message
+        self.assertIn(
+            message,
+            response.data['message']
         )
 
 

--- a/edxval/tests/test_views.py
+++ b/edxval/tests/test_views.py
@@ -2,6 +2,7 @@
 """
 Tests for Video Abstraction Layer views
 """
+from __future__ import unicode_literals
 import json
 import unittest
 
@@ -446,7 +447,7 @@ class VideoListTest(APIAuthTestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response = json.loads(response.content)
         # Check that invalid course keys have been filtered out.
-        self.assertEqual(response['courses'], [{u'edX/DemoX/Astonomy': None}])
+        self.assertEqual(response['courses'], [{'edX/DemoX/Astonomy': None}])
 
     def test_post_non_latin_client_video_id(self):
         """
@@ -475,7 +476,7 @@ class VideoListTest(APIAuthTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.data.get("edx_video_id")[0],
-            u'video with this edx video id already exists.'
+            'video with this edx video id already exists.'
         )
         videos = len(self.client.get("/edxval/videos/").data)
         self.assertEqual(videos, 1)
@@ -764,15 +765,15 @@ class VideoImagesViewTest(APIAuthTestCase):
     @data(
         {
             'post_data': {},
-            'message': u'course_id and edx_video_id and generated_images must be specified to update a video image.'
+            'message': 'course_id and edx_video_id and generated_images must be specified to update a video image.'
         },
         {
             'post_data': {'course_id': 'does_not_exit_course', 'edx_video_id': 'super-soaker', 'generated_images': []},
-            'message': u'CourseVideo not found for course_id: does_not_exit_course'
+            'message': 'CourseVideo not found for course_id: does_not_exit_course'
         },
         {
             'post_data': {'course_id': 'test_course_id', 'edx_video_id': 'does_not_exit_video', 'generated_images': []},
-            'message': u'CourseVideo not found for course_id: test_course_id'
+            'message': 'CourseVideo not found for course_id: test_course_id'
         },
         {
             'post_data': {'course_id': 'test_course_id', 'edx_video_id': 'super-soaker', 'generated_images': [1, 2, 3]},

--- a/edxval/urls.py
+++ b/edxval/urls.py
@@ -1,6 +1,7 @@
 """
 Url file for django app edxval.
 """
+from __future__ import unicode_literals
 
 from django.conf.urls import url
 

--- a/edxval/utils.py
+++ b/edxval/utils.py
@@ -2,6 +2,8 @@
 Util methods to be used in api and models.
 """
 
+from __future__ import unicode_literals
+
 from django.conf import settings
 from django.core.files.storage import get_storage_class
 
@@ -128,7 +130,7 @@ def video_image_path(video_image_instance, filename):  # pylint:disable=unused-a
         video_image_instance (VideoImage): This is passed automatically by models.CustomizableImageField
         filename (str): name of image file
     """
-    return u'{}{}'.format(settings.VIDEO_IMAGE_SETTINGS.get('DIRECTORY_PREFIX', ''), filename)
+    return '{}{}'.format(settings.VIDEO_IMAGE_SETTINGS.get('DIRECTORY_PREFIX', ''), filename)
 
 
 def get_video_image_storage():

--- a/edxval/views.py
+++ b/edxval/views.py
@@ -1,6 +1,8 @@
 """
 Views file for django app edxval.
 """
+from __future__ import unicode_literals
+
 import logging
 
 from django.core.exceptions import ValidationError
@@ -229,7 +231,7 @@ class VideoImagesView(APIView):
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={
-                    'message': u'{missing} must be specified to update a video image.'.format(
+                    'message': '{missing} must be specified to update a video image.'.format(
                         missing=' and '.join(missing)
                     )
                 }
@@ -241,12 +243,13 @@ class VideoImagesView(APIView):
 
         try:
             course_video = CourseVideo.objects.select_related('video_image').get(
-                course_id=unicode(course_id), video__edx_video_id=edx_video_id
+                course_id=course_id,
+                video__edx_video_id=edx_video_id
             )
         except CourseVideo.DoesNotExist:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
-                data={'message': u'CourseVideo not found for course_id: {course_id}'.format(course_id=course_id)}
+                data={'message': 'CourseVideo not found for course_id: {course_id}'.format(course_id=course_id)}
             )
 
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
--e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-6a#egg=django-oauth2-provider==0.2.7-fork-edx-6
--e git+https://github.com/edx/django-rest-framework-oauth.git@f0b503fda8c254a38f97fef802ded4f5fe367f7a#egg=djangorestframework-oauth
+-e git+https://github.com/edx/django-oauth2-provider.git@1.2.2#egg=django-oauth2-provider==1.2.2
+-e git+https://github.com/edx/django-rest-framework-oauth.git@392d3b423788718c04e7aab8dba17a56f95d757f#egg=djangorestframework-oauth
 pillow==4.2.1
 boto==2.46.1
 django-model-utils==2.3.1

--- a/urls.py
+++ b/urls.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 


### PR DESCRIPTION
- I started with travis to make sure that the library really doesn't support Python 3, then I did the normal steps in Django's [Porting to Python 3](https://docs.djangoproject.com/en/1.11/topics/python3/) documentation by replacing `unicode` with `str` wherever this is necessary. 
- Some tests passed, some failed because the project started treating `ImageFile` objects as `str` so I fixed it by opening it as a `'rb'`. 
- Migration step also failed because the `regex` value in [RegexValidator(regex=b'^[a-zA-Z0-9\\-_]*$'](https://github.com/ahmedaljazzar/edx-val/blob/368ac3b918775634016474b43826c36a3167e0a3/edxval/migrations/0001_initial.py) is bytestrings, so I treated it as an `str`. 
- The final step was to update django-rest-framework-oauth and django-oauth2-provider versions to fix the syntax error in them in Python 3.
 
Each step is written in a single commit (Checked are the commits that fixes the tests):
- [x] [7481758](https://github.com/edx/edx-val/pull/91/commits/7481758b1928e2bd1038bf9a6ecfdd02b395cdee) Start with [.travis.yml](https://github.com/ahmedaljazzar/edx-val/blob/7481758b1928e2bd1038bf9a6ecfdd02b395cdee/.travis.yml)
- [x] [7481758](https://github.com/edx/edx-val/pull/91/commits/4f5194fb4e076a95bdbb1f419ab7e55cad08bdd6) Replace unicode with str.
- [x] [4f5194f](https://github.com/edx/edx-val/pull/91/commits/4f5194fb4e076a95bdbb1f419ab7e55cad08bdd6) Fix unicode strings and ImageFile.
- [x] [e1fb696](https://github.com/edx/edx-val/pull/91/commits/e1fb696602797e389ed87c96fd4a1cd2384b0aca) Fix migrations.
- [x] [368ac3b](https://github.com/edx/edx-val/pull/91/commits/62dc6f67846d2751abb95e3c9b2df3459a510bd9) Update django-rest-framework-oauth and django-oauth2-provider versions.
- [x] ~[2c95639](https://github.com/edx/edx-val/pull/91/commits/2c956390ba4ea89ab96c19b360d20656b83a6100) Create the missing migrations from the master.~