### PR TITLE
Remove transcript preferences

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -266,6 +266,20 @@ def create_or_update_transcript_preferences(course_id, **preferences):
     return TranscriptPreferenceSerializer(transcript_preference).data
 
 
+def remove_transcript_preferences(course_id):
+    """
+    Deletes course-wide transcript preferences.
+
+    Arguments:
+        course_id(str): course id
+    """
+    try:
+        transcript_preference = TranscriptPreference.objects.get(course_id=course_id)
+        transcript_preference.delete()
+    except TranscriptPreference.DoesNotExist:
+        pass
+
+
 def get_course_video_image_url(course_id, edx_video_id):
     """
     Returns course video image url or None if no image found

--- a/edxval/tests/test_api.py
+++ b/edxval/tests/test_api.py
@@ -1731,6 +1731,34 @@ class TranscriptPreferencesTest(TestCase):
         transcript_preferences = api.get_transcript_preferences(self.course_id)
         self.assert_prefs(transcript_preferences, cielo24_prefs)
 
+    def test_remove_transcript_preferences(self):
+        """
+        Verify that `remove_transcript_preferences` api method works as expected.
+        """
+        # Verify that transcript preferences exist.
+        transcript_preferences = api.get_transcript_preferences(self.course_id)
+        self.assertIsNotNone(transcript_preferences)
+
+        # Remove course wide transcript preferences.
+        api.remove_transcript_preferences(self.course_id)
+
+        # Verify now transcript preferences no longer exist.
+        transcript_preferences = api.get_transcript_preferences(self.course_id)
+        self.assertIsNone(transcript_preferences)
+
+    def test_remove_transcript_preferences_not_found(self):
+        """
+        Verify that `remove_transcript_preferences` api method works as expected when no record is found.
+        """
+        course_id = 'dummy-course-id'
+
+        # Verify that transcript preferences do not exist.
+        transcript_preferences = api.get_transcript_preferences(course_id)
+        self.assertIsNone(transcript_preferences)
+
+        # Verify that calling `remove_transcript_preferences` does not break the code.
+        api.remove_transcript_preferences(course_id)
+
     def test_update_transcript_preferences(self):
         """
         Verify that `create_or_update_transcript_preferences` api function updates as expected


### PR DESCRIPTION
This PR adds an api end point which will let us remove course-wide transcript preferences. This would mainly come in handy when user selects a **N/A** option from Video Uploads page.