### PR TITLE
PLAT-1413 Remove obsolete TEMPLATE_* settings

### DIFF
--- a/edxval/settings.py
+++ b/edxval/settings.py
@@ -3,7 +3,6 @@ Settings file for django app edxval.
 """
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),
@@ -86,13 +85,6 @@ STATICFILES_FINDERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = ')5n@d^*763&amp;##4c(vtzg6&amp;%d7^yiee@5zk-n$rw7djcmz+4u4n'
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-    # 'django.template.loaders.eggs.Loader',
-)
-
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -107,12 +99,6 @@ ROOT_URLCONF = 'urls'
 
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'edxval.wsgi.application'
-
-TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-)
 
 INSTALLED_APPS = (
     'django.contrib.auth',


### PR DESCRIPTION
These settings are deprecated in Django 1.8 and removed in 1.10.  They were auto-generated by an old version of Django, and aren't even used in the tests which this file is meant for.