### PR TITLE
Make Transcript create/update more versatile

### DIFF
--- a/edxval/tests/test_api.py
+++ b/edxval/tests/test_api.py
@@ -1693,10 +1693,8 @@ class TranscriptTest(TestCase):
         self.transcript_url = api.create_or_update_video_transcript(
             self.video_id,
             'ur',
-            'The_Arrow.srt',
-            TranscriptFormat.SRT,
-            provider=TranscriptProviderType.CUSTOM,
-            file_data=File(open(self.arrow_transcript_path)),
+            metadata={'file_format': TranscriptFormat.SRT},
+            file_data=File(open(self.arrow_transcript_path))
         )
 
     @data(
@@ -1818,9 +1816,11 @@ class TranscriptTest(TestCase):
         transcript_url = api.create_or_update_video_transcript(
             video_id=transcript_data['video_id'],
             language_code=transcript_data['language_code'],
-            file_name=transcript_data['name'],
-            file_format=transcript_data['file_format'],
-            provider=transcript_data['provider'],
+            metadata=dict(
+                file_name=transcript_data['name'],
+                file_format=transcript_data['file_format'],
+                provider=transcript_data['provider']
+            )
         )
         self.assertEqual(transcript_url, transcript_data['name'])
 
@@ -1849,32 +1849,49 @@ class TranscriptTest(TestCase):
     @data(
         {
             'file_data': None,
+            'file_name': 'overwatch.sjson',
             'file_format': TranscriptFormat.SJSON,
+            'language_code': 'da',
             'provider': TranscriptProviderType.CIELO24
         },
         {
             'file_data': ContentFile(FILE_DATA),
+            'file_name': None,
             'file_format': TranscriptFormat.SRT,
+            'language_code': 'es',
             'provider': TranscriptProviderType.THREE_PLAY_MEDIA
         },
     )
     @unpack
-    def test_create_or_update_video_transcript(self, file_data, file_format, provider):
+    def test_create_or_update_video_transcript(self, file_data, file_name, file_format, language_code, provider):
         """
         Verify that `create_or_update_video_transcript` api function updates existing transcript as expected.
         """
         video_transcript = VideoTranscript.objects.get(video_id=self.video_id, language_code='ur')
         self.assertIsNotNone(video_transcript)
 
-        file_name = 'overwatch.{}'.format(file_format)
         transcript_url = api.create_or_update_video_transcript(
-            self.video_id, 'ur', file_name, file_format, provider, file_data
+            video_id=self.video_id,
+            language_code='ur',
+            metadata=dict(
+                provider=provider,
+                language_code=language_code,
+                file_name=file_name,
+                file_format=file_format
+            ),
+            file_data=file_data
         )
-        video_transcript = VideoTranscript.objects.get(video_id=self.video_id, language_code='ur')
 
+        # Now, Querying Video Transcript with previous/old language code leads to DoesNotExist
+        with self.assertRaises(VideoTranscript.DoesNotExist):
+            VideoTranscript.objects.get(video_id=self.video_id, language_code='ur')
+
+        # Assert the updates to the transcript object
+        video_transcript = VideoTranscript.objects.get(video_id=self.video_id, language_code=language_code)
         self.assertEqual(transcript_url, video_transcript.url())
         self.assertEqual(video_transcript.file_format, file_format)
         self.assertEqual(video_transcript.provider, provider)
+        self.assertEqual(video_transcript.language_code, language_code)
 
         if file_data:
             self.assertTrue(transcript_url.startswith(settings.VIDEO_TRANSCRIPTS_SETTINGS['DIRECTORY_PREFIX']))
@@ -1904,7 +1921,10 @@ class TranscriptTest(TestCase):
         Verify that `create_or_update_video_transcript` api function raise exceptions on invalid values.
         """
         with self.assertRaises(exception) as transcript_exception:
-            api.create_or_update_video_transcript(self.video_id, 'ur', 'overwatch.srt', file_format, provider)
+            api.create_or_update_video_transcript(self.video_id, 'ur', metadata={
+                'provider': provider,
+                'file_format': file_format
+            })
 
         self.assertEqual(transcript_exception.exception.message, exception_message)
 
@@ -1918,12 +1938,10 @@ class TranscriptTest(TestCase):
 
         # This will replace the transcript for an existing video and delete the existing transcript
         new_transcript_url = api.create_or_update_video_transcript(
-            self.video_id,
-            'ur',
-            'overwatch.srt',
-            TranscriptFormat.SRT,
-            TranscriptProviderType.CIELO24,
-            ContentFile(FILE_DATA)
+            video_id=self.video_id,
+            language_code='ur',
+            metadata=dict(provider=TranscriptProviderType.CIELO24),
+            file_data=ContentFile(FILE_DATA)
         )
 
         # Verify that new transcript is set to video

--- a/edxval/views.py
+++ b/edxval/views.py
@@ -4,9 +4,7 @@ Views file for django app edxval.
 import logging
 
 from django.core.exceptions import ValidationError
-from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
-from django.views.decorators.http import last_modified
 from rest_framework import generics, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import DjangoModelPermissions
@@ -14,12 +12,16 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_oauth.authentication import OAuth2Authentication
 
-from edxval.api import (create_or_update_video_transcript,
-                        get_video_transcript, update_video_status)
-from edxval.models import (CourseVideo, Profile, TranscriptFormat,
-                           TranscriptProviderType, Video, VideoImage,
-                           VideoTranscript)
-from edxval.serializers import TranscriptSerializer, VideoSerializer
+from edxval.api import create_or_update_video_transcript
+from edxval.models import (
+    CourseVideo,
+    TranscriptFormat,
+    TranscriptProviderType,
+    Video,
+    VideoImage,
+    VideoTranscript
+)
+from edxval.serializers import VideoSerializer
 
 LOGGER = logging.getLogger(__name__)  # pylint: disable=C0103
 
@@ -148,13 +150,11 @@ class VideoTranscriptView(APIView):
 
         transcript = VideoTranscript.get_or_none(video_id, language_code)
         if transcript is None:
-            create_or_update_video_transcript(
-                video_id,
-                language_code,
-                transcript_name,
-                file_format,
-                provider,
-            )
+            create_or_update_video_transcript(video_id, language_code, metadata={
+                'provider': provider,
+                'file_name': transcript_name,
+                'file_format': file_format
+            })
             response = Response(status=status.HTTP_200_OK)
         else:
             message = (


### PR DESCRIPTION
## [EDUCATOR-2022](https://openedx.atlassian.net/browse/EDUCATOR-2022)
Refactor `VideoTranscript.create_or_update` to be capable to update transcript file_name/file_data, language_code, file_format and provider.