### PR TITLE
Fix transcript has no file attached to it

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -843,11 +843,16 @@ def create_trancript_file(video_id, language_code, file_format, resource_fs, sta
         language_code=language_code,
         file_format=file_format
     )
-    transcript_data = get_video_transcript_data(video_id, language_code)
-    if transcript_data:
-        transcript_content = transcript_data['content']
-        with resource_fs.open(transcript_name, 'wb') as f:
-            f.write(transcript_content)
+    try:
+        transcript_data = get_video_transcript_data(video_id, language_code)
+        if transcript_data:
+            transcript_content = transcript_data['content']
+            with resource_fs.open(transcript_name, 'wb') as f:
+                f.write(transcript_content)
+    except Exception:
+        # Do not raise exception in case no transcript file is found for now.
+        # TODO: Remove this - EDUCATOR-2173
+        pass
 
 
 def create_transcripts_xml(video_id, video_el, resource_fs, static_dir):


### PR DESCRIPTION
Fix when video_transcript.transcript is empty i.e transcript has no file attached to it.

Traceback:
```
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 578, in export_to_xml
    super(XmlDescriptor, self).add_xml_to_node(node)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 444, in add_xml_to_node
    xml_object = self.definition_to_xml(self.runtime.export_fs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/video_module/video_module.py", line 729, in definition_to_xml
    course_id=unicode(self.runtime.course_id.for_branch(None))
  File "/edx/app/edxapp/venvs/edxapp/src/edxval/edxval/api.py", line 826, in export_to_xml
    return create_transcripts_xml(video_id, video_el, resource_fs, static_dir)
  File "/edx/app/edxapp/venvs/edxapp/src/edxval/edxval/api.py", line 878, in create_transcripts_xml
    create_trancript_file(video_id, language_code, file_format, resource_fs, static_dir)
  File "/edx/app/edxapp/venvs/edxapp/src/edxval/edxval/api.py", line 846, in create_trancript_file
    transcript_data = get_video_transcript_data(video_id, language_code)
  File "/edx/app/edxapp/venvs/edxapp/src/edxval/edxval/api.py", line 255, in get_video_transcript_data
    return dict(file_name=video_transcript.filename, content=video_transcript.transcript.file.read())
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/files.py", line 49, in _get_file
    self._require_file()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/files.py", line 46, in _require_file
    raise ValueError("The '%s' attribute has no file associated with it." % self.field.name)
ValueError: The 'transcript' attribute has no file associated with it.
```

This also caters cross-platform import-export scenario:
```
1. Export AA course from prod.
2. import in local
3. Observe transcript records created in VAL.
4. Export course.
5. Observe we get No such file exist.
```