### PR TITLE
Backward compatible video transcripts export

### DIFF
--- a/edxval/exceptions.py
+++ b/edxval/exceptions.py
@@ -62,3 +62,10 @@ class InvalidTranscriptProvider(ValError):
     This error is raised when an transcript provider is not supported
     """
     pass
+
+
+class TranscriptsGenerationException(ValError):
+    """
+    This error is raised when a transcript content is not parse-able in specified format.
+    """
+    pass

--- a/edxval/tests/test_transcript_utils.py
+++ b/edxval/tests/test_transcript_utils.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for transcript utils.
+"""
+import ddt
+import json
+import textwrap
+import unittest
+
+from edxval.transcript_utils import Transcript
+from edxval.exceptions import TranscriptsGenerationException
+
+
+@ddt.ddt
+class TestTranscriptUtils(unittest.TestCase):
+    """
+    Tests transcripts conversion util.
+    """
+    def setUp(self):
+        super(TestTranscriptUtils, self).setUp()
+
+        self.srt_transcript = textwrap.dedent("""\
+            0
+            00:00:10,500 --> 00:00:13,000
+            Elephant&#39;s Dream 大象的梦想
+
+            1
+            00:00:15,000 --> 00:00:18,000
+            At the left we can see...
+
+        """)
+
+        self.sjson_transcript = textwrap.dedent("""\
+            {
+                "start": [
+                    10500,
+                    15000
+                ],
+                "end": [
+                    13000,
+                    18000
+                ],
+                "text": [
+                    "Elephant&#39;s Dream 大象的梦想",
+                    "At the left we can see..."
+                ]
+            }
+        """)
+
+    @ddt.data(
+        ('invalid_input_format', 'sjson'),
+        ('sjson', 'invalid_output_format'),
+        ('invalid_input_format', 'invalid_output_format')
+    )
+    @ddt.unpack
+    def test_invalid_transcript_format(self, input_format, output_format):
+        """
+        Tests that transcript conversion raises `AssertionError` on invalid input/output formats.
+        """
+        with self.assertRaises(AssertionError):
+            Transcript.convert(self.sjson_transcript, input_format, output_format)
+
+    def test_convert_srt_to_srt(self):
+        """
+        Tests that srt to srt conversion works as expected.
+        """
+        expected = self.srt_transcript.decode('utf-8')
+        actual = Transcript.convert(self.srt_transcript, 'srt', 'srt')
+        self.assertEqual(actual, expected)
+
+    def test_convert_sjson_to_srt(self):
+        """
+        Tests that the sjson transcript is successfully converted into srt format.
+        """
+        expected = self.srt_transcript.decode('utf-8')
+        actual = Transcript.convert(self.sjson_transcript, 'sjson', 'srt')
+        self.assertEqual(actual, expected)
+
+    def test_convert_srt_to_sjson(self):
+        """
+        Tests that the srt transcript is successfully converted into sjson format.
+        """
+        expected = self.sjson_transcript.decode('utf-8')
+        actual = Transcript.convert(self.srt_transcript, 'srt', 'sjson')
+        self.assertDictEqual(json.loads(actual), json.loads(expected))
+
+    def test_convert_invalid_srt_to_sjson(self):
+        """
+        Tests that TranscriptsGenerationException was raises on trying
+        to convert invalid srt transcript to sjson.
+        """
+        invalid_srt_transcript = 'invalid SubRip file content'
+        with self.assertRaises(TranscriptsGenerationException):
+            Transcript.convert(invalid_srt_transcript, 'srt', 'sjson')

--- a/edxval/transcript_utils.py
+++ b/edxval/transcript_utils.py
@@ -1,0 +1,117 @@
+"""
+A module containing transcripts utils.
+"""
+import json
+from six import text_type
+
+from pysrt import SubRipFile, SubRipItem, SubRipTime
+from pysrt.srtexc import Error
+
+from edxval.exceptions import TranscriptsGenerationException
+
+
+class Transcript(object):
+    """
+    Container for transcript methods.
+    """
+    SRT = 'srt'
+    SJSON = 'sjson'
+
+    @staticmethod
+    def generate_sjson_from_srt(srt_subs):
+        """
+        Generate transcripts from sjson to SubRip (*.srt).
+
+        Arguments:
+            srt_subs(SubRip): "SRT" subs object
+
+        Returns:
+            Subs converted to "SJSON" format.
+        """
+        sub_starts = []
+        sub_ends = []
+        sub_texts = []
+        for sub in srt_subs:
+            sub_starts.append(sub.start.ordinal)
+            sub_ends.append(sub.end.ordinal)
+            sub_texts.append(sub.text.replace('\n', ' '))
+
+        sjson_subs = {
+            'start': sub_starts,
+            'end': sub_ends,
+            'text': sub_texts
+        }
+        return sjson_subs
+
+    @staticmethod
+    def generate_srt_from_sjson(sjson_subs):
+        """
+        Generate transcripts from sjson to SubRip (*.srt).
+
+        Arguments:
+            sjson_subs (dict): `sjson` subs.
+
+        Returns:
+            Subtitles in SRT format.
+        """
+
+        output = ''
+
+        equal_len = len(sjson_subs['start']) == len(sjson_subs['end']) == len(sjson_subs['text'])
+        if not equal_len:
+            return output
+
+        for i in range(len(sjson_subs['start'])):
+            item = SubRipItem(
+                index=i,
+                start=SubRipTime(milliseconds=sjson_subs['start'][i]),
+                end=SubRipTime(milliseconds=sjson_subs['end'][i]),
+                text=sjson_subs['text'][i]
+            )
+            output += (unicode(item))
+            output += '\n'
+        return output
+
+    @classmethod
+    def convert(cls, content, input_format, output_format):
+        """
+        Convert transcript `content` from `input_format` to `output_format`.
+
+        Arguments:
+            content: Transcript content byte-stream.
+            input_format: Input transcript format.
+            output_format: Output transcript format.
+
+        Accepted input formats: sjson, srt.
+        Accepted output format: srt, sjson.
+
+        Raises:
+            TranscriptsGenerationException: On parsing the invalid srt
+            content during conversion from srt to sjson.
+        """
+        assert input_format in ('srt', 'sjson')
+        assert output_format in ('srt', 'sjson')
+
+        # Decode the content with utf-8-sig which will also
+        # skip byte order mark(BOM) character if found.
+        content = content.decode('utf-8-sig')
+
+        if input_format == output_format:
+            return content
+
+        if input_format == 'srt':
+
+            if output_format == 'sjson':
+                try:
+                    # With error handling (set to 'ERROR_RAISE'), we will be getting
+                    # the exception if something went wrong in parsing the transcript.
+                    srt_subs = SubRipFile.from_string(content, error_handling=SubRipFile.ERROR_RAISE)
+                except Error as ex:  # Base exception from pysrt
+                    raise TranscriptsGenerationException(text_type(ex))
+
+                return json.dumps(cls.generate_sjson_from_srt(srt_subs))
+
+        if input_format == 'sjson':
+
+            if output_format == 'srt':
+                return cls.generate_srt_from_sjson(json.loads(content))

--- a/edxval/utils.py
+++ b/edxval/utils.py
@@ -192,11 +192,11 @@ def create_file_in_fs(file_data, file_name, file_system, static_dir):
     Arguments:
         file_data (str): Data to store into the file.
         file_name (str): File name of the file to be created.
-        resource_fs (OSFS): Import file system.
+        file_system (OSFS): Import file system.
         static_dir (str): The Directory to retrieve transcript file.
     """
     with file_system.open(combine(static_dir, file_name), 'wb') as f:
-        f.write(file_data)
+        f.write(file_data.encode('utf-8'))
 
 
 def get_transcript_format(transcript_content):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edxval',
-    version='0.1.14',
+    version='0.1.15',
     author='edX',
     url='http://github.com/edx/edx-val',
     description='edx-val',


### PR DESCRIPTION
# [EDUCATOR-2914](https://openedx.atlassian.net/browse/EDUCATOR-2914)
### Export transcripts metadata along with xml  …

 - Transcript files are exported into course OLX in `.SRT` format.
 - Transcript language to filename maps is also returned along with xml, so that, it can be used by platform to update old metadata fields for backward compatibility.
 - fix tests