### PR TITLE
Do not link a video to course if it has no playable encodings

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -1027,6 +1027,16 @@ def import_from_xml(xml, edx_video_id, resource_fs, static_dir, external_transcr
                 'bitrate': encoded_video_el.get('bitrate'),
             })
 
+        if not data['encoded_videos']:
+            # Video's status does not get included in video xml at the time of export. So, at this point,
+            # we cannot tell from xml that whether a video had an external status. But if encoded videos
+            # are not set, the chances are, the video was an external one, in which case, we will not link
+            # it to the course(s). Even if the video wasn't an external one and it is having 0 encodes in
+            # xml, it does not have a side effect if not linked to a course, since the video was already
+            # non-playable.
+            data['status'] = EXTERNAL_VIDEO_STATUS
+            data['courses'] = []
+
         # Create external video if no edx_video_id.
         edx_video_id = create_video(data)
     else:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edxval',
-    version='0.1.17',
+    version='0.1.18',
     author='edX',
     url='http://github.com/edx/edx-val',
     description='edx-val',


### PR DESCRIPTION
At the time of import, do not link a video to course if it has no encodings in xml