### PR TITLE
Fixed download transcript 500 error

### DIFF
--- a/edxval/models.py
+++ b/edxval/models.py
@@ -427,7 +427,7 @@ class VideoTranscript(TimeStampedModel):
         """
         client_id, __ = os.path.splitext(self.video.client_video_id)
         file_name = u'{name}-{language}.{format}'.format(
-            name=client_id,
+            name=unicode(client_id, 'utf-8'),
             language=self.language_code,
             format=self.file_format
         )


### PR DESCRIPTION
## [EDUCATOR-3335](https://openedx.atlassian.net/browse/EDUCATOR-3335)

### Description
Converted client_id to unicode to make sure that the filename generated is a unicode. If the client_id is not converted to unicode (given that it has a unicode character) the generated filename is a byte string.

**Sandbox**
In progress

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @Qubad786 
- [ ] @noraiz-anwar  

### Post-review
- [ ] Rebase and squash commits
