### PR TITLE
fix transcript download failure

### DIFF
--- a/edxval/models.py
+++ b/edxval/models.py
@@ -430,8 +430,8 @@ class VideoTranscript(TimeStampedModel):
             name=client_id,
             language=self.language_code,
             format=self.file_format
-        )
-
+        ).replace('\n', ' ')
+        
         return file_name
 
     @classmethod

--- a/edxval/tests/constants.py
+++ b/edxval/tests/constants.py
@@ -380,6 +380,12 @@ VIDEO_DICT_UPDATE_ANIMAL = dict(
     encoded_videos=[],
 )
 
+VIDEO_DICT_NEW_LINE = dict(
+    client_video_id="New \n Line",
+    duration=888.00,
+    edx_video_id="new-line-not-allowed",
+    status="test",
+)
 
 TRANSCRIPT_DATA = {
     "overwatch": """

--- a/edxval/tests/test_models.py
+++ b/edxval/tests/test_models.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from django.test import TestCase
+
+from edxval.models import Video, VideoTranscript
+from edxval.tests import constants
+
+
+class VideoTranscriptTest(TestCase):
+    """
+    Test VideoTranscript model
+    """
+
+    def setUp(self):
+        """
+        Creates Profile objects and a video object
+        """
+        self.transcript_data = constants.VIDEO_TRANSCRIPT_CIELO24
+        super(VideoTranscriptTest, self).setUp()
+    
+    def test_filename_property_new_line(self):
+        """
+        Test that filename does not contain any "\n". 
+        New line is not permmited in response headers.
+        """
+        video = Video.objects.create(**constants.VIDEO_DICT_NEW_LINE)
+        video_trancript = VideoTranscript.objects.create(
+            video=video,
+            language_code=self.transcript_data['language_code'],
+            file_format=self.transcript_data['file_format'],
+            provider=self.transcript_data['provider'],
+        )
+
+        self.assertFalse('\n' in video_trancript.filename)


### PR DESCRIPTION
## [EDUCATOR-3794](https://openedx.atlassian.net/browse/EDUCATOR-3794)

### Description
New line `\n` is not allowed in response headers. Replacing any `\n` present in filename with space.

### Reviewers
- [x] @Qubad786 
- [ ] @awaisdar001 
 
### Post-review
- [ ] Rebase and squash commits