### PR TITLE
Add basic pagination in video upload page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '0.1.24'
+VERSION = '0.1.25'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
## [EDUCATOR-3566](https://openedx.atlassian.net/browse/EDUCATOR-3566)

### Description

Adding basic pagination as a workaround to unblock course teams. 

### Sandbox
- [ ] https://studio-pagination.sandbox.edx.org/videos/course-v1:edX+DemoX+Demo_Course

Pagination can be enabled/disabled for courses using course waffle flag https://pagination.sandbox.edx.org/admin/waffle_utils/waffleflagcourseoverridemodel/


### Reviewers
- [x] @Rabia23 
- [x] @asadazam93 

FYI: @fysheets 
 
### Post-review
- [ ] Rebase and squash commits
