### PR TITLE
PROD-386: Adding status to verify OEP-7 compliance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,7 @@ Retrieve all profiles for a video with `edx_video_id`="example"
 Developing
 ----------
 
+
 First, create a virtual environment:
 
 .. code-block:: bash

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -6,7 +6,7 @@ owner: fysheets
 
 oeps:
   oep-2: true
-  oep-7: false
+  oep-7: true
   oep-18: true
 tags:
   - video pipline


### PR DESCRIPTION
I ran "python-modernize -w .", but this resulted in no changes, so the repo was already OEP-7 compliant. I just changed to openedx.yaml to reflect real state of repo.