### PR TITLE
DE-1824: step 3 of 4 in renaming 'exists' field in ThirdPartyTranscriptCredentialsState to 'has_creds' (v1.2.1)

### DIFF
--- a/edxval/admin.py
+++ b/edxval/admin.py
@@ -115,9 +115,7 @@ class TranscriptPreferenceAdmin(admin.ModelAdmin):
 
 class ThirdPartyTranscriptCredentialsStateAdmin(admin.ModelAdmin):
     """ Admin for ThirdPartyTranscriptCredentialsState  """
-    # TODO: change "exists" to "has_creds" once the new column exists, in step 3
-    # of the renaming process.
-    list_display = ('org', 'provider', 'exists', 'created', 'modified')
+    list_display = ('org', 'provider', 'has_creds', 'created', 'modified')
 
     model = ThirdPartyTranscriptCredentialsState
     verbose_name = 'Organization Transcript Credential State'

--- a/edxval/api.py
+++ b/edxval/api.py
@@ -225,8 +225,7 @@ def get_transcript_credentials_state_for_org(org, provider=None):
         query_filter['provider'] = provider
 
     return {
-        # TODO: rename credential.exists to credential.has_creds in step 3 of renaming.
-        credential.provider: credential.exists
+        credential.provider: credential.has_creds
         for credential in ThirdPartyTranscriptCredentialsState.objects.filter(**query_filter)
     }
 

--- a/edxval/models.py
+++ b/edxval/models.py
@@ -659,8 +659,6 @@ class ThirdPartyTranscriptCredentialsState(TimeStampedModel):
         max_length=20,
         choices=TranscriptProviderType.CHOICES,
     )
-    # TODO remove exists in step 3 of renaming.
-    exists = models.NullBooleanField(default=False, help_text=u'Transcript credentials state')
     has_creds = models.BooleanField(default=False, help_text=u'Transcript credentials state')
 
     @classmethod
@@ -668,11 +666,10 @@ class ThirdPartyTranscriptCredentialsState(TimeStampedModel):
         """
         Update or create credentials state.
         """
-        # TODO: remove 'exists' in step 3 of renaming.
         instance, created = cls.objects.update_or_create(
             org=org,
             provider=provider,
-            defaults={'exists': has_creds, 'has_creds': has_creds},
+            defaults={'has_creds': has_creds},
         )
 
         return instance, created
@@ -685,9 +682,8 @@ class ThirdPartyTranscriptCredentialsState(TimeStampedModel):
             edX has Cielo24 credentials
             edX doesn't have 3PlayMedia credentials
         """
-        # TODO: rename exists to has_creds in set 3 of renaming.
         return u'{org} {state} {provider} credentials'.format(
-            org=self.org, provider=self.provider, state='has' if self.exists else "doesn't have"
+            org=self.org, provider=self.provider, state='has' if self.has_creds else "doesn't have"
         )
 
 

--- a/edxval/tests/test_api.py
+++ b/edxval/tests/test_api.py
@@ -3014,12 +3014,11 @@ class TranscripCredentialsStateTest(TestCase):
         Tests setup
         """
         super(TranscripCredentialsStateTest, self).setUp()
-        # TODO: remove exists in step 3 of renaming.
         third_party_trans_true = ThirdPartyTranscriptCredentialsState.objects.create(
-            org='edX', provider='Cielo24', exists=True, has_creds=True
+            org='edX', provider='Cielo24', has_creds=True
         )
         third_party_trans_false = ThirdPartyTranscriptCredentialsState.objects.create(
-            org='edX', provider='3PlayMedia', exists=False, has_creds=False
+            org='edX', provider='3PlayMedia', has_creds=False
         )
 
         # casting an instance to a string returns a valid value.
@@ -3040,7 +3039,10 @@ class TranscripCredentialsStateTest(TestCase):
 
         credentials_state = ThirdPartyTranscriptCredentialsState.objects.get(org=kwargs['org'])
         for key in kwargs:
-            self.assertEqual(getattr(credentials_state, key), kwargs[key])
+            # The API continues to use 'exists' but the database uses 'has_creds' because
+            # 'exists' is a SQL keyword.
+            credentials_state_key = 'has_creds' if key == 'exists' else key
+            self.assertEqual(getattr(credentials_state, credentials_state_key), kwargs[key])
 
     @data(
         {

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '1.2.0'
+VERSION = '1.2.1'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
Remove code for 'exists' w/o migration.

Update version to 1.1.34.

Replaces #196 