### PR TITLE
Update DRF to 3.9.4.

### DIFF
--- a/edxval/tests/test_serializers.py
+++ b/edxval/tests/test_serializers.py
@@ -99,7 +99,7 @@ class SerializerTests(TestCase):
         )
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
-            str(serializer.errors['courses'][0]),
+            str(serializer.errors.get('courses').get('course_id')[0]),
             "Ensure this value has at most 255 characters (it has 300)."
         )
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,7 +6,6 @@ boto
 Django>=1.11
 django-model-utils
 edx-django-oauth2-provider
-djangorestframework==3.7.7
 edx-drf-extensions
 -e git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 django-storages

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,3 +14,6 @@ futures ; python_version == "2.7"
 # Constraining this since the newer versions require Python 3
 more-itertools==5.0.0
 
+# Constraining this since we haven't handled newer versions of Django Rest Framework
+# and we want to allow edx-platform to update this separately.
+djangorestframework==3.9.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,7 +33,7 @@ django-storages==1.8
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.26
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.7.7
+djangorestframework==3.9.4
 docopt==0.6.2             # via coveralls
 docutils==0.15.2          # via readme-renderer
 edx-django-oauth2-provider==1.3.5

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -29,7 +29,7 @@ django-storages==1.8
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.26
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.7.7
+djangorestframework==3.9.4
 docutils==0.15.2          # via readme-renderer
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==2.0.2   # via edx-drf-extensions

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,7 +20,7 @@ django-model-utils==3.2.0
 django-storages==1.8
 django-waffle==0.18.0     # via edx-django-utils, edx-drf-extensions
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.7.7
+djangorestframework==3.9.4
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==2.0.2   # via edx-drf-extensions
 edx-drf-extensions==2.4.5

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '1.1.33'
+VERSION = '1.2.0'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
Udpates DRF to the latest version supporting both Python 2 and 3.

I had to update the return value of an error but I checked in edx-platform that we don't pull out these errors in a way that would break with this change.

I updated the version to 1.2.0 because making it 1.1.34 seemed a bit overkill.