### PR TITLE
Add new status to VideoStatusView

### DIFF
--- a/edxval/tests/test_views.py
+++ b/edxval/tests/test_views.py
@@ -926,11 +926,16 @@ class VideoStatusViewTest(APIAuthTestCase):
             'message': None,
             'status_code': status.HTTP_200_OK,
         },
+        {
+            'patch_data': {'edx_video_id': 'super-soaker', 'status': 'transcode_active'},
+            'message': None,
+            'status_code': status.HTTP_200_OK,
+        },
     )
     @unpack
-    def test_transcript_status(self, patch_data, message, status_code):
+    def test_video_status(self, patch_data, message, status_code):
         """
-        Tests PATCHing video transcript status.
+        Tests PATCHing video status.
         """
         response = self.client.patch(self.url, patch_data, format='json')
         self.assertEqual(response.status_code, status_code)

--- a/edxval/views.py
+++ b/edxval/views.py
@@ -34,6 +34,7 @@ LOGGER = logging.getLogger(__name__)
 VALID_VIDEO_STATUSES = [
     'transcription_in_progress',
     'transcript_ready',
+    'transcode_active',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '1.2.4'
+VERSION = '1.2.5'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
In order to use `VideoStatusView` from vem, we need to add new status to the **VALID_VIDEO_STATUSES**

Status Added: 
`trancode_active`: Set after encoding jobs have started