### PR TITLE
Remove python2 testing, update requirements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - 2.7
   - 3.5
 
 env:
@@ -14,13 +13,6 @@ matrix:
   include:
   - python: 3.5
     env: TOXENV=quality
-  exclude:
-  - python: 2.7
-    env: TOXENV=django20
-  - python: 2.7
-    env: TOXENV=django21
-  - python: 2.7
-    env: TOXENV=django22
 
 
 install:

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,11 +8,6 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# futures is part of the builtin python in python3
-futures ; python_version == "2.7"
-
-# Constraining this since the newer versions require Python 3
-more-itertools==5.0.0
 
 # Constraining this since we haven't handled newer versions of Django Rest Framework
 # and we want to allow edx-platform to update this separately.
@@ -23,6 +18,3 @@ django-model-utils<4.0
 
 # zipp 2.0.0 requires Python >= 3.6
 zipp==1.0.0
-
-# be able to run pytest on Python 2.7 and 3.x
-pytest<5.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,33 +8,32 @@
 appdirs==1.4.3            # via fs, virtualenv
 argparse==1.4.0           # via caniusepython3
 astroid==2.3.3            # via pylint, pylint-celery
-atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
 backports.functools-lru-cache==1.6.1  # via caniusepython3
 bleach==3.1.4             # via readme-renderer
 boto==2.49.0              # via -r requirements/base.in
 caniusepython3==7.2.0     # via -r requirements/quality.in
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via pysrt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.1              # via click-log, edx-lint, pip-tools
-coverage==5.0.4           # via -r requirements/test.in, coveralls, pytest-cov
-coveralls==1.11.1         # via -r requirements/travis.in
-cryptography==2.8         # via django-fernet-fields
+coverage==5.1             # via -r requirements/test.in, coveralls, pytest-cov
+coveralls==2.0.0          # via -r requirements/travis.in
+cryptography==2.9         # via django-fernet-fields
 ddt==1.3.1                # via -r requirements/test.in
-diff-cover==2.6.0         # via -r requirements/dev.in
+diff-cover==2.6.1         # via -r requirements/dev.in
 distlib==0.3.0            # via caniusepython3, virtualenv
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in
 django-storages==1.9.1    # via -r requirements/base.in
 django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
-django==2.2.11            # via -r requirements/base.in, django-fernet-fields, django-model-utils, django-storages, drf-jwt, edx-django-utils, edx-drf-extensions, rest-condition
+django==2.2.12            # via -r requirements/base.in, django-fernet-fields, django-model-utils, django-storages, drf-jwt, edx-django-utils, edx-drf-extensions, rest-condition
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, drf-jwt, edx-drf-extensions, rest-condition
 docopt==0.6.2             # via coveralls
 docutils==0.16            # via readme-renderer
 drf-jwt==1.14.0           # via edx-drf-extensions
-edx-django-utils==3.1     # via edx-drf-extensions
+edx-django-utils==3.2.0   # via edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/base.in
 edx-lint==1.4.1           # via -r requirements/quality.in
 edx-opaque-keys==2.0.2    # via edx-drf-extensions
@@ -54,11 +53,11 @@ lxml==4.5.0               # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
-more-itertools==5.0.0     # via -c requirements/constraints.txt, pytest, zipp
+more-itertools==8.2.0     # via pytest, zipp
 newrelic==5.10.0.138      # via edx-django-utils
 packaging==20.3           # via caniusepython3, pytest, tox
 pathlib2==2.3.5           # via pytest
-pbr==5.4.4                # via stevedore
+pbr==5.4.5                # via stevedore
 pip-tools==4.5.1          # via -r requirements/dev.in
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via diff-cover, pytest, tox
@@ -76,11 +75,11 @@ pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via edx-opaque-keys
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 pysrt==1.1.2              # via -r requirements/base.in
 pytest-cov==2.8.1         # via -r requirements/test.in
-pytest-django==3.8.0      # via -r requirements/test.in
-pytest==4.6.9             # via -c requirements/constraints.txt, pytest-cov, pytest-django
+pytest-django==3.9.0      # via -r requirements/test.in
+pytest==5.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via edx-drf-extensions
 pytz==2019.3              # via django, fs
 readme-renderer==25.0     # via twine
@@ -89,19 +88,19 @@ requests==2.23.0          # via caniusepython3, coveralls, edx-drf-extensions, p
 responses==0.10.12        # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via astroid, bleach, cryptography, diff-cover, django-waffle, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, mock, more-itertools, packaging, pathlib2, pip-tools, pyjwkest, pytest, python-dateutil, readme-renderer, responses, stevedore, tox, virtualenv
+six==1.14.0               # via astroid, bleach, cryptography, diff-cover, django-waffle, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, readme-renderer, responses, stevedore, tox, virtualenv
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -r requirements/travis.in
 tox==3.14.6               # via -r requirements/travis.in, tox-battery
-tqdm==4.44.1              # via twine
+tqdm==4.45.0              # via twine
 twine==1.15.0             # via -r requirements/quality.in
 typed-ast==1.4.1          # via astroid
 typing==3.7.4.1           # via fs
 urllib3==1.25.8           # via requests
-virtualenv==20.0.15       # via tox
+virtualenv==20.0.17       # via tox
 wcwidth==0.1.9            # via pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via astroid

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,30 +8,29 @@
 appdirs==1.4.3            # via fs
 argparse==1.4.0           # via caniusepython3
 astroid==2.3.3            # via pylint, pylint-celery
-atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
 backports.functools-lru-cache==1.6.1  # via caniusepython3
 bleach==3.1.4             # via readme-renderer
 boto==2.49.0              # via -r requirements/base.in
 caniusepython3==7.2.0     # via -r requirements/quality.in
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via pysrt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.1              # via click-log, edx-lint
-coverage==5.0.4           # via -r requirements/test.in, pytest-cov
-cryptography==2.8         # via django-fernet-fields
+coverage==5.1             # via -r requirements/test.in, pytest-cov
+cryptography==2.9         # via django-fernet-fields
 ddt==1.3.1                # via -r requirements/test.in
 distlib==0.3.0            # via caniusepython3
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in
 django-storages==1.9.1    # via -r requirements/base.in
 django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
-django==2.2.11            # via -r requirements/base.in, django-fernet-fields, django-model-utils, django-storages, drf-jwt, edx-django-utils, edx-drf-extensions, rest-condition
+django==2.2.12            # via -r requirements/base.in, django-fernet-fields, django-model-utils, django-storages, drf-jwt, edx-django-utils, edx-drf-extensions, rest-condition
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via readme-renderer
 drf-jwt==1.14.0           # via edx-drf-extensions
-edx-django-utils==3.1     # via edx-drf-extensions
+edx-django-utils==3.2.0   # via edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/base.in
 edx-lint==1.4.1           # via -r requirements/quality.in
 edx-opaque-keys==2.0.2    # via edx-drf-extensions
@@ -45,11 +44,11 @@ lazy-object-proxy==1.4.3  # via astroid
 lxml==4.5.0               # via -r requirements/base.in
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
-more-itertools==5.0.0     # via -c requirements/constraints.txt, pytest
+more-itertools==8.2.0     # via pytest
 newrelic==5.10.0.138      # via edx-django-utils
 packaging==20.3           # via caniusepython3, pytest
 pathlib2==2.3.5           # via pytest
-pbr==5.4.4                # via stevedore
+pbr==5.4.5                # via stevedore
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via pytest
 psutil==1.2.1             # via edx-django-utils
@@ -66,11 +65,11 @@ pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via edx-opaque-keys
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 pysrt==1.1.2              # via -r requirements/base.in
 pytest-cov==2.8.1         # via -r requirements/test.in
-pytest-django==3.8.0      # via -r requirements/test.in
-pytest==4.6.9             # via -c requirements/constraints.txt, pytest-cov, pytest-django
+pytest-django==3.9.0      # via -r requirements/test.in
+pytest==5.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via edx-drf-extensions
 pytz==2019.3              # via django, fs
 readme-renderer==25.0     # via twine
@@ -79,11 +78,11 @@ requests==2.23.0          # via caniusepython3, edx-drf-extensions, pyjwkest, re
 responses==0.10.12        # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via astroid, bleach, cryptography, django-waffle, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, mock, more-itertools, packaging, pathlib2, pyjwkest, pytest, python-dateutil, readme-renderer, responses, stevedore
+six==1.14.0               # via astroid, bleach, cryptography, django-waffle, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, responses, stevedore
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
-tqdm==4.44.1              # via twine
+tqdm==4.45.0              # via twine
 twine==1.15.0             # via -r requirements/quality.in
 typed-ast==1.4.1          # via astroid
 typing==3.7.4.1           # via fs

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,14 +6,13 @@
 #
 -e git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1  # via -r requirements/base.in
 appdirs==1.4.3            # via fs
-atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
 boto==2.49.0              # via -r requirements/base.in
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via pysrt, requests
-coverage==5.0.4           # via -r requirements/test.in, pytest-cov
-cryptography==2.8         # via django-fernet-fields
+coverage==5.1             # via -r requirements/test.in, pytest-cov
+cryptography==2.9         # via django-fernet-fields
 ddt==1.3.1                # via -r requirements/test.in
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in
@@ -21,7 +20,7 @@ django-storages==1.9.1    # via -r requirements/base.in
 django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via edx-drf-extensions
-edx-django-utils==3.1     # via edx-drf-extensions
+edx-django-utils==3.2.0   # via edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/base.in
 edx-opaque-keys==2.0.2    # via edx-drf-extensions
 enum34==1.1.10            # via -r requirements/base.in
@@ -31,11 +30,11 @@ idna==2.9                 # via requests
 importlib-metadata==1.6.0  # via pluggy, pytest
 lxml==4.5.0               # via -r requirements/base.in
 mock==3.0.5               # via -r requirements/test.in
-more-itertools==5.0.0     # via -c requirements/constraints.txt, pytest
+more-itertools==8.2.0     # via pytest
 newrelic==5.10.0.138      # via edx-django-utils
 packaging==20.3           # via pytest
 pathlib2==2.3.5           # via pytest
-pbr==5.4.4                # via stevedore
+pbr==5.4.5                # via stevedore
 pluggy==0.13.1            # via pytest
 psutil==1.2.1             # via edx-django-utils
 py==1.8.1                 # via pytest
@@ -44,18 +43,18 @@ pycryptodomex==3.9.7      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via drf-jwt
 pymongo==3.10.1           # via edx-opaque-keys
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 pysrt==1.1.2              # via -r requirements/base.in
 pytest-cov==2.8.1         # via -r requirements/test.in
-pytest-django==3.8.0      # via -r requirements/test.in
-pytest==4.6.9             # via -c requirements/constraints.txt, pytest-cov, pytest-django
+pytest-django==3.9.0      # via -r requirements/test.in
+pytest==5.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via edx-drf-extensions
 pytz==2019.3              # via django, fs
 requests==2.23.0          # via edx-drf-extensions, pyjwkest, responses
 responses==0.10.12        # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via cryptography, django-waffle, edx-drf-extensions, edx-opaque-keys, fs, mock, more-itertools, packaging, pathlib2, pyjwkest, pytest, python-dateutil, responses, stevedore
+six==1.14.0               # via cryptography, django-waffle, edx-drf-extensions, edx-opaque-keys, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, responses, stevedore
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
 typing==3.7.4.1           # via fs

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,26 +5,26 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via virtualenv
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-coverage==5.0.4           # via coveralls
-coveralls==1.11.1         # via -r requirements/travis.in
+coverage==5.1             # via coveralls
+coveralls==2.0.0          # via -r requirements/travis.in
 distlib==0.3.0            # via virtualenv
 docopt==0.6.2             # via coveralls
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
 importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
 importlib-resources==1.4.0  # via virtualenv
-more-itertools==5.0.0     # via -c requirements/constraints.txt, zipp
+more-itertools==8.2.0     # via zipp
 packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 requests==2.23.0          # via coveralls
-six==1.14.0               # via more-itertools, packaging, tox, virtualenv
+six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -r requirements/travis.in
 tox==3.14.6               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.8           # via requests
-virtualenv==20.0.15       # via tox
+virtualenv==20.0.17       # via tox
 zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35}-django111,py{35}-django{20,21,22}
+envlist = py{35}-django{111,20,21,22}
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR removes the python2 tests from .travis.yml and tox.ini, as they are no longer needed.  Also ran `make upgrade` to update requirements.