### PR TITLE
Remove django-fernet-fields from requirements

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,7 +4,6 @@
 
 boto
 Django>=1.11
-django-fernet-fields
 django-model-utils
 edx-drf-extensions
 -e git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,6 +7,7 @@
 -e git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1  # via -r requirements/base.in
 appdirs==1.4.4            # via fs, virtualenv
 argparse==1.4.0           # via caniusepython3
+asgiref==3.2.7            # via django
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 backports.functools-lru-cache==1.6.1  # via caniusepython3
@@ -14,21 +15,18 @@ bleach==3.1.5             # via readme-renderer
 boto==2.49.0              # via -r requirements/base.in
 caniusepython3==7.2.0     # via -r requirements/quality.in
 certifi==2020.4.5.1       # via requests
-cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via pysrt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint, pip-tools
 coverage==5.1             # via -r requirements/test.in, coveralls, pytest-cov
 coveralls==2.0.0          # via -r requirements/travis.in
-cryptography==2.9.2       # via django-fernet-fields
-ddt==1.4.0                # via -r requirements/test.in
+ddt==1.4.1                # via -r requirements/test.in
 diff-cover==2.6.1         # via -r requirements/dev.in
 distlib==0.3.0            # via caniusepython3, virtualenv
-django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-storages==1.9.1    # via -r requirements/base.in
 django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/base.in, django-fernet-fields, django-model-utils, django-storages, drf-jwt, edx-django-utils, edx-drf-extensions, rest-condition
+django==3.0.6             # via -r requirements/base.in, django-model-utils, django-storages, drf-jwt, edx-django-utils, edx-drf-extensions, rest-condition
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, drf-jwt, edx-drf-extensions, rest-condition
 docopt==0.6.2             # via coveralls
 docutils==0.16            # via readme-renderer
@@ -42,30 +40,28 @@ filelock==3.0.12          # via tox, virtualenv
 fs==2.4.11                # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via importlib-resources, inflect, pluggy, pytest, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
-inflect==3.0.2            # via jinja2-pluralize
+importlib-metadata==1.6.0  # via inflect, keyring, pluggy, pytest, tox, twine, virtualenv
+inflect==4.1.0            # via jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via diff-cover, jinja2-pluralize
+keyring==21.2.1           # via twine
 lazy-object-proxy==1.4.3  # via astroid
-lxml==4.5.0               # via -r requirements/base.in
+lxml==4.5.1               # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -r requirements/test.in
-more-itertools==8.2.0     # via pytest, zipp
+mock==4.0.2               # via -r requirements/test.in
+more-itertools==8.3.0     # via pytest, zipp
 newrelic==5.12.1.141      # via edx-django-utils
 nose==1.3.7               # via -r requirements/test.in
-packaging==20.3           # via bleach, caniusepython3, pytest, tox
-pathlib2==2.3.5           # via pytest
+packaging==20.4           # via bleach, caniusepython3, pytest, tox
 pbr==5.4.5                # via stevedore
 pip-tools==5.1.2          # via -r requirements/dev.in
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via diff-cover, pytest, tox
 psutil==1.2.1             # via edx-django-utils
 py==1.8.1                 # via pytest, tox
-pycodestyle==2.5.0        # via -r requirements/quality.in
-pycparser==2.20           # via cffi
+pycodestyle==2.6.0        # via -r requirements/quality.in
 pycryptodomex==3.9.7      # via pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pygments==2.6.1           # via diff-cover, readme-renderer
@@ -89,23 +85,22 @@ requests==2.23.0          # via caniusepython3, coveralls, edx-drf-extensions, p
 responses==0.10.14        # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.14.0               # via astroid, bleach, cryptography, diff-cover, django-waffle, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, readme-renderer, responses, stevedore, tox, virtualenv
+six==1.14.0               # via astroid, bleach, diff-cover, django-waffle, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, packaging, pip-tools, pyjwkest, python-dateutil, readme-renderer, responses, stevedore, tox, virtualenv
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
-toml==0.10.0              # via tox
-tox-battery==0.5.2        # via -r requirements/travis.in
+toml==0.10.1              # via tox
+tox-battery==0.6.0        # via -r requirements/travis.in
 tox==3.15.0               # via -r requirements/travis.in, tox-battery
 tqdm==4.46.0              # via twine
-twine==1.15.0             # via -r requirements/quality.in
+twine==3.1.1              # via -r requirements/quality.in
 typed-ast==1.4.1          # via astroid
-typing==3.7.4.1           # via fs
 urllib3==1.25.9           # via requests
 virtualenv==20.0.20       # via tox
 wcwidth==0.1.9            # via pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via astroid
-zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources
+zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -7,6 +7,7 @@
 -e git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1  # via -r requirements/base.in
 appdirs==1.4.4            # via fs
 argparse==1.4.0           # via caniusepython3
+asgiref==3.2.7            # via django
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 backports.functools-lru-cache==1.6.1  # via caniusepython3
@@ -14,19 +15,16 @@ bleach==3.1.5             # via readme-renderer
 boto==2.49.0              # via -r requirements/base.in
 caniusepython3==7.2.0     # via -r requirements/quality.in
 certifi==2020.4.5.1       # via requests
-cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via pysrt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coverage==5.1             # via -r requirements/test.in, pytest-cov
-cryptography==2.9.2       # via django-fernet-fields
-ddt==1.4.0                # via -r requirements/test.in
+ddt==1.4.1                # via -r requirements/test.in
 distlib==0.3.0            # via caniusepython3
-django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-storages==1.9.1    # via -r requirements/base.in
 django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
-django==2.2.12            # via -r requirements/base.in, django-fernet-fields, django-model-utils, django-storages, drf-jwt, edx-django-utils, edx-drf-extensions, rest-condition
+django==3.0.6             # via -r requirements/base.in, django-model-utils, django-storages, drf-jwt, edx-django-utils, edx-drf-extensions, rest-condition
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via readme-renderer
 drf-jwt==1.14.0           # via edx-drf-extensions
@@ -38,24 +36,23 @@ enum34==1.1.10            # via -r requirements/base.in
 fs==2.4.11                # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via pluggy, pytest
+importlib-metadata==1.6.0  # via keyring, pluggy, pytest, twine
 isort==4.3.21             # via -r requirements/quality.in, pylint
+keyring==21.2.1           # via twine
 lazy-object-proxy==1.4.3  # via astroid
-lxml==4.5.0               # via -r requirements/base.in
+lxml==4.5.1               # via -r requirements/base.in
 mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -r requirements/test.in
-more-itertools==8.2.0     # via pytest
+mock==4.0.2               # via -r requirements/test.in
+more-itertools==8.3.0     # via pytest, zipp
 newrelic==5.12.1.141      # via edx-django-utils
 nose==1.3.7               # via -r requirements/test.in
-packaging==20.3           # via bleach, caniusepython3, pytest
-pathlib2==2.3.5           # via pytest
+packaging==20.4           # via bleach, caniusepython3, pytest
 pbr==5.4.5                # via stevedore
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via pytest
 psutil==1.2.1             # via edx-django-utils
 py==1.8.1                 # via pytest
-pycodestyle==2.5.0        # via -r requirements/quality.in
-pycparser==2.20           # via cffi
+pycodestyle==2.6.0        # via -r requirements/quality.in
 pycryptodomex==3.9.7      # via pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pygments==2.6.1           # via readme-renderer
@@ -79,14 +76,13 @@ requests==2.23.0          # via caniusepython3, edx-drf-extensions, pyjwkest, re
 responses==0.10.14        # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.14.0               # via astroid, bleach, cryptography, django-waffle, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, responses, stevedore
+six==1.14.0               # via astroid, bleach, django-waffle, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, packaging, pyjwkest, python-dateutil, readme-renderer, responses, stevedore
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
 tqdm==4.46.0              # via twine
-twine==1.15.0             # via -r requirements/quality.in
+twine==3.1.1              # via -r requirements/quality.in
 typed-ast==1.4.1          # via astroid
-typing==3.7.4.1           # via fs
 urllib3==1.25.9           # via requests
 wcwidth==0.1.9            # via pytest
 webencodings==0.5.1       # via bleach

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,15 +6,13 @@
 #
 -e git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1  # via -r requirements/base.in
 appdirs==1.4.4            # via fs
+asgiref==3.2.7            # via django
 attrs==19.3.0             # via pytest
 boto==2.49.0              # via -r requirements/base.in
 certifi==2020.4.5.1       # via requests
-cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via pysrt, requests
 coverage==5.1             # via -r requirements/test.in, pytest-cov
-cryptography==2.9.2       # via django-fernet-fields
-ddt==1.4.0                # via -r requirements/test.in
-django-fernet-fields==0.6  # via -r requirements/base.in
+ddt==1.4.1                # via -r requirements/test.in
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-storages==1.9.1    # via -r requirements/base.in
 django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
@@ -28,18 +26,16 @@ fs==2.4.11                # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
 importlib-metadata==1.6.0  # via pluggy, pytest
-lxml==4.5.0               # via -r requirements/base.in
-mock==3.0.5               # via -r requirements/test.in
-more-itertools==8.2.0     # via pytest
+lxml==4.5.1               # via -r requirements/base.in
+mock==4.0.2               # via -r requirements/test.in
+more-itertools==8.3.0     # via pytest
 newrelic==5.12.1.141      # via edx-django-utils
 nose==1.3.7               # via -r requirements/test.in
-packaging==20.3           # via pytest
-pathlib2==2.3.5           # via pytest
+packaging==20.4           # via pytest
 pbr==5.4.5                # via stevedore
 pluggy==0.13.1            # via pytest
 psutil==1.2.1             # via edx-django-utils
 py==1.8.1                 # via pytest
-pycparser==2.20           # via cffi
 pycryptodomex==3.9.7      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via drf-jwt
@@ -55,10 +51,9 @@ requests==2.23.0          # via edx-drf-extensions, pyjwkest, responses
 responses==0.10.14        # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.14.0               # via cryptography, django-waffle, edx-drf-extensions, edx-opaque-keys, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, responses, stevedore
+six==1.14.0               # via django-waffle, edx-drf-extensions, edx-opaque-keys, fs, packaging, pyjwkest, python-dateutil, responses, stevedore
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
-typing==3.7.4.1           # via fs
 urllib3==1.25.9           # via requests
 wcwidth==0.1.9            # via pytest
 zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -13,18 +13,17 @@ distlib==0.3.0            # via virtualenv
 docopt==0.6.2             # via coveralls
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
-more-itertools==8.2.0     # via zipp
-packaging==20.3           # via tox
+importlib-metadata==1.6.0  # via pluggy, tox, virtualenv
+more-itertools==8.3.0     # via zipp
+packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pyparsing==2.4.7          # via packaging
 requests==2.23.0          # via coveralls
 six==1.14.0               # via packaging, tox, virtualenv
-toml==0.10.0              # via tox
-tox-battery==0.5.2        # via -r requirements/travis.in
+toml==0.10.1              # via tox
+tox-battery==0.6.0        # via -r requirements/travis.in
 tox==3.15.0               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.9           # via requests
 virtualenv==20.0.20       # via tox
-zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources
+zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata


### PR DESCRIPTION
We no longer need the third party package `django-fernet-fields`