### PR TITLE
Fix video images not set properly

### DIFF
--- a/edxval/models.py
+++ b/edxval/models.py
@@ -358,7 +358,8 @@ class VideoImage(TimeStampedModel):
                 if not video_image.image.name:
                     file_name = generated_images[0]
 
-            video_image.image.name = file_name
+            if file_name:
+                video_image.image.name = file_name
 
         video_image.save()
         return video_image, created

--- a/edxval/tests/test_models.py
+++ b/edxval/tests/test_models.py
@@ -4,7 +4,7 @@
 
 from django.test import TestCase
 
-from edxval.models import Video, VideoTranscript
+from edxval.models import CourseVideo, Video, VideoImage, VideoTranscript
 from edxval.tests import constants
 
 
@@ -35,3 +35,42 @@ class VideoTranscriptTest(TestCase):
 
         self.assertNotIn('\n', video_trancript.filename)
         assert str(video_trancript) == "en Transcript for new-line-not-allowed"
+
+
+class VideoImageTest(TestCase):
+    """
+    Tests for VideoImage model.
+    """
+
+    def setUp(self):
+        """
+        Create Video and VideoImage object
+        """
+        super(VideoImageTest, self).setUp()
+        course_id = 'test-course'
+        video = Video.objects.create(**constants.VIDEO_DICT_NEW_LINE)
+
+        self.course_video = CourseVideo.objects.create(video=video, course_id=course_id)
+        self.video_image = VideoImage.objects.create(course_video=self.course_video)
+        self.generated_images = ['test-thumbnail-1.jpeg', 'test-thumbnail-2.jpeg']
+
+    def test_generated_images_when_no_image_exists(self):
+        """
+        Test that if generated_images of video image are updated when no previous
+        manual upload exists, then first generated_image is set as the thumbnail.
+        """
+        video_image, _ = VideoImage.create_or_update(self.course_video, generated_images=self.generated_images)
+        self.assertEqual(video_image.image, self.generated_images[0])
+
+    def test_generated_images_when_image_exists(self):
+        """
+        Test that if generated_images of video image are updated when previous
+        manual upload exists, then image field does not change.
+        """
+        manually_uploaded_img = 'manual-upload.jpeg'
+        self.video_image.image = manually_uploaded_img
+        self.video_image.save()
+
+        video_image, _ = VideoImage.create_or_update(self.course_video, generated_images=self.generated_images)
+        self.assertNotEqual(video_image.image, self.generated_images[0])
+        self.assertEqual(video_image.image, manually_uploaded_img)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '1.3.5'
+VERSION = '1.3.6'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
If encode job is not complete and course team member tries to upload a thumbnail manually to the video, the images disappears when encoding completes. VAL sets the value to None is such cases. Precedence should be given to manually uploaded thumbnails over MC generated thumbnails.

[PROD-1760](https://openedx.atlassian.net/browse/PROD-1760)