### PR TITLE
[BD-6] Use std enum lib in python3.8

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,8 +6,8 @@ boto
 Django>=1.11
 django-fernet-fields
 django-model-utils
-edx-drf-extensions
 django-storages
-enum34
+edx-drf-extensions
+enum34; python_version<'3.6'
 lxml
 pysrt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,7 @@ astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 bleach==3.1.5             # via readme-renderer
 boto==2.49.0              # via -r requirements/base.in
-certifi==2020.4.5.2       # via requests
+certifi==2020.6.20        # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via pysrt, requests
 click-log==0.3.2          # via edx-lint
@@ -23,7 +23,7 @@ distlib==0.3.0            # via virtualenv
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-storages==1.9.1    # via -r requirements/base.in
-django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
+django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
 django==2.2.13            # via -r requirements/base.in, django-fernet-fields, django-model-utils, django-storages, drf-jwt, edx-django-utils, edx-drf-extensions, rest-condition
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, drf-jwt, edx-drf-extensions, rest-condition
 docopt==0.6.2             # via coveralls
@@ -33,7 +33,7 @@ edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.in
 edx-lint==1.4.1           # via -r requirements/quality.in
 edx-opaque-keys==2.1.0    # via edx-drf-extensions
-enum34==1.1.10            # via -r requirements/base.in
+enum34==1.1.10 ; python_version < "3.6"  # via -r requirements/base.in
 filelock==3.0.12          # via tox, virtualenv
 fs==2.4.11                # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
@@ -50,7 +50,7 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.4.0     # via pytest, zipp
-newrelic==5.14.0.142      # via edx-django-utils
+newrelic==5.14.1.144      # via edx-django-utils
 nose==1.3.7               # via -r requirements/test.in
 packaging==20.4           # via bleach, pytest, tox
 pathlib2==2.3.5           # via pytest
@@ -59,10 +59,10 @@ pip-tools==5.2.1          # via -r requirements/dev.in
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via diff-cover, pytest, tox
 psutil==1.2.1             # via edx-django-utils
-py==1.8.1                 # via pytest, tox
+py==1.9.0                 # via pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pycparser==2.20           # via cffi
-pycryptodomex==3.9.7      # via pyjwkest
+pycryptodomex==3.9.8      # via pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pygments==2.6.1           # via diff-cover, readme-renderer
 pyjwkest==1.4.2           # via edx-drf-extensions
@@ -81,11 +81,11 @@ python-dateutil==2.8.1    # via edx-drf-extensions
 pytz==2020.1              # via django, fs
 readme-renderer==26.0     # via twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.23.0          # via coveralls, edx-drf-extensions, pyjwkest, requests-toolbelt, responses, twine
+requests==2.24.0          # via coveralls, edx-drf-extensions, pyjwkest, requests-toolbelt, responses, twine
 responses==0.10.15        # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via astroid, bleach, cryptography, diff-cover, django-waffle, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, readme-renderer, responses, stevedore, tox, virtualenv
+six==1.15.0               # via astroid, bleach, cryptography, diff-cover, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, readme-renderer, responses, stevedore, tox, virtualenv
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
@@ -97,8 +97,8 @@ twine==1.15.0             # via -r requirements/quality.in
 typed-ast==1.4.1          # via astroid
 typing==3.7.4.1           # via fs
 urllib3==1.25.9           # via requests
-virtualenv==20.0.23       # via tox
-wcwidth==0.2.4            # via pytest
+virtualenv==20.0.25       # via tox
+wcwidth==0.2.5            # via pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via astroid
 zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -9,7 +9,7 @@ astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 bleach==3.1.5             # via readme-renderer
 boto==2.49.0              # via -r requirements/base.in
-certifi==2020.4.5.2       # via requests
+certifi==2020.6.20        # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via pysrt, requests
 click-log==0.3.2          # via edx-lint
@@ -20,7 +20,7 @@ ddt==1.4.1                # via -r requirements/test.in
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-storages==1.9.1    # via -r requirements/base.in
-django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
+django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
 django==2.2.13            # via -r requirements/base.in, django-fernet-fields, django-model-utils, django-storages, drf-jwt, edx-django-utils, edx-drf-extensions, rest-condition
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via readme-renderer
@@ -29,7 +29,7 @@ edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.in
 edx-lint==1.4.1           # via -r requirements/quality.in
 edx-opaque-keys==2.1.0    # via edx-drf-extensions
-enum34==1.1.10            # via -r requirements/base.in
+enum34==1.1.10 ; python_version < "3.6"  # via -r requirements/base.in
 fs==2.4.11                # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
@@ -40,7 +40,7 @@ lxml==4.5.1               # via -r requirements/base.in
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.4.0     # via pytest
-newrelic==5.14.0.142      # via edx-django-utils
+newrelic==5.14.1.144      # via edx-django-utils
 nose==1.3.7               # via -r requirements/test.in
 packaging==20.4           # via bleach, pytest
 pathlib2==2.3.5           # via pytest
@@ -48,10 +48,10 @@ pbr==5.4.5                # via stevedore
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via pytest
 psutil==1.2.1             # via edx-django-utils
-py==1.8.1                 # via pytest
+py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pycparser==2.20           # via cffi
-pycryptodomex==3.9.7      # via pyjwkest
+pycryptodomex==3.9.8      # via pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pygments==2.6.1           # via readme-renderer
 pyjwkest==1.4.2           # via edx-drf-extensions
@@ -70,11 +70,11 @@ python-dateutil==2.8.1    # via edx-drf-extensions
 pytz==2020.1              # via django, fs
 readme-renderer==26.0     # via twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.23.0          # via edx-drf-extensions, pyjwkest, requests-toolbelt, responses, twine
+requests==2.24.0          # via edx-drf-extensions, pyjwkest, requests-toolbelt, responses, twine
 responses==0.10.15        # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via astroid, bleach, cryptography, django-waffle, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, responses, stevedore
+six==1.15.0               # via astroid, bleach, cryptography, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, responses, stevedore
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
@@ -83,7 +83,7 @@ twine==1.15.0             # via -r requirements/quality.in
 typed-ast==1.4.1          # via astroid
 typing==3.7.4.1           # via fs
 urllib3==1.25.9           # via requests
-wcwidth==0.2.4            # via pytest
+wcwidth==0.2.5            # via pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via astroid
 zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,7 +7,7 @@
 appdirs==1.4.4            # via fs
 attrs==19.3.0             # via pytest
 boto==2.49.0              # via -r requirements/base.in
-certifi==2020.4.5.2       # via requests
+certifi==2020.6.20        # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via pysrt, requests
 coverage==5.1             # via -r requirements/test.in, pytest-cov
@@ -16,13 +16,13 @@ ddt==1.4.1                # via -r requirements/test.in
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-storages==1.9.1    # via -r requirements/base.in
-django-waffle==0.20.0     # via edx-django-utils, edx-drf-extensions
+django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via edx-drf-extensions
 edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.in
 edx-opaque-keys==2.1.0    # via edx-drf-extensions
-enum34==1.1.10            # via -r requirements/base.in
+enum34==1.1.10 ; python_version < "3.6"  # via -r requirements/base.in
 fs==2.4.11                # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
@@ -30,16 +30,16 @@ importlib-metadata==1.6.1  # via pluggy, pytest
 lxml==4.5.1               # via -r requirements/base.in
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.4.0     # via pytest
-newrelic==5.14.0.142      # via edx-django-utils
+newrelic==5.14.1.144      # via edx-django-utils
 nose==1.3.7               # via -r requirements/test.in
 packaging==20.4           # via pytest
 pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via stevedore
 pluggy==0.13.1            # via pytest
 psutil==1.2.1             # via edx-django-utils
-py==1.8.1                 # via pytest
+py==1.9.0                 # via pytest
 pycparser==2.20           # via cffi
-pycryptodomex==3.9.7      # via pyjwkest
+pycryptodomex==3.9.8      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via drf-jwt
 pymongo==3.10.1           # via edx-opaque-keys
@@ -50,16 +50,16 @@ pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.3             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via edx-drf-extensions
 pytz==2020.1              # via django, fs
-requests==2.23.0          # via edx-drf-extensions, pyjwkest, responses
+requests==2.24.0          # via edx-drf-extensions, pyjwkest, responses
 responses==0.10.15        # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via cryptography, django-waffle, edx-drf-extensions, edx-opaque-keys, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, responses, stevedore
+six==1.15.0               # via cryptography, edx-drf-extensions, edx-opaque-keys, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, responses, stevedore
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
 typing==3.7.4.1           # via fs
 urllib3==1.25.9           # via requests
-wcwidth==0.2.4            # via pytest
+wcwidth==0.2.5            # via pytest
 zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via virtualenv
-certifi==2020.4.5.2       # via requests
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 coverage==5.1             # via coveralls
 coveralls==2.0.0          # via -r requirements/travis.in
@@ -18,13 +18,13 @@ importlib-resources==2.0.1  # via virtualenv
 more-itertools==8.4.0     # via zipp
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
-py==1.8.1                 # via tox
+py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
-requests==2.23.0          # via coveralls
+requests==2.24.0          # via coveralls
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
 tox==3.15.2               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.9           # via requests
-virtualenv==20.0.23       # via tox
+virtualenv==20.0.25       # via tox
 zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
Use enum lib from std instead of enum34, enum34 is not needed in python>3.4

https://stackoverflow.com/a/45716067

I think that we should use `enum34; python_version<'3.4'`, but I am using python_version<'3.6' in order to not change anything for python3.5

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179