### PR TITLE
[BD-6] Remove enum34 from dependencies since python2.7 support was dropped.

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,6 +8,5 @@ django-fernet-fields
 django-model-utils
 django-storages
 edx-drf-extensions
-enum34; python_version<'3.6'
 lxml
 pysrt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,7 +33,6 @@ edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.in
 edx-lint==1.4.1           # via -r requirements/quality.in
 edx-opaque-keys==2.1.0    # via edx-drf-extensions
-enum34==1.1.10 ; python_version < "3.6"  # via -r requirements/base.in
 filelock==3.0.12          # via tox, virtualenv
 fs==2.4.11                # via -r requirements/test.in
 future==0.18.2            # via pyjwkest

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -29,7 +29,6 @@ edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.in
 edx-lint==1.4.1           # via -r requirements/quality.in
 edx-opaque-keys==2.1.0    # via edx-drf-extensions
-enum34==1.1.10 ; python_version < "3.6"  # via -r requirements/base.in
 fs==2.4.11                # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -22,7 +22,6 @@ drf-jwt==1.14.0           # via edx-drf-extensions
 edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.0.0  # via -r requirements/base.in
 edx-opaque-keys==2.1.0    # via edx-drf-extensions
-enum34==1.1.10 ; python_version < "3.6"  # via -r requirements/base.in
 fs==2.4.11                # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '1.3.7'
+VERSION = '1.3.8'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
enum34 is causing problems in python3.8 tests of edx-platform because it has incompatibility with recent versions of python, the error the error happens while importing the re module in these python versions.

This library is a backport of enum of python3.4 made for python<3.4, therefore is not needed anymore.

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179
- [ ] @jmbowman 