### PR TITLE
drf-jwt==1.16.2 is causing failures in ecom, platform and discovery. So pining it here.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,3 +15,8 @@ djangorestframework==3.9.4
 
 # zipp 2.0.0 requires Python >= 3.6
 zipp==1.0.0
+
+
+# latest version drf-jwt==1.16.2 is causing failures in ecom, platform and discovery.
+# So avoiding that until fix that issue.
+drf-jwt<1.15.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint, pip-tools
 coverage==5.2             # via -r requirements/test.in, coveralls, pytest-cov
 coveralls==2.1.0          # via -r requirements/travis.in
-cryptography==2.9.2       # via django-fernet-fields, pyjwt
+cryptography==2.9.2       # via django-fernet-fields
 ddt==1.4.1                # via -r requirements/test.in
 diff-cover==3.0.1         # via -r requirements/dev.in
 distlib==0.3.1            # via virtualenv
@@ -28,7 +28,7 @@ django==2.2.14            # via -r requirements/base.in, django-fernet-fields, d
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, drf-jwt, edx-drf-extensions, rest-condition
 docopt==0.6.2             # via coveralls
 docutils==0.16            # via readme-renderer
-drf-jwt==1.16.2           # via edx-drf-extensions
+drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.1.0  # via -r requirements/base.in
 edx-lint==1.5.0           # via -r requirements/quality.in
@@ -64,7 +64,7 @@ pycryptodomex==3.9.8      # via pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pygments==2.6.1           # via diff-cover, readme-renderer
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt
+pyjwt==1.7.1              # via drf-jwt
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
@@ -95,7 +95,7 @@ twine==1.15.0             # via -r requirements/quality.in
 typed-ast==1.4.1          # via astroid
 typing==3.7.4.1           # via fs
 urllib3==1.25.9           # via requests
-virtualenv==20.0.25       # via tox
+virtualenv==20.0.26       # via tox
 wcwidth==0.2.5            # via pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via astroid

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -15,7 +15,7 @@ chardet==3.0.4            # via pysrt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coverage==5.2             # via -r requirements/test.in, pytest-cov
-cryptography==2.9.2       # via django-fernet-fields, pyjwt
+cryptography==2.9.2       # via django-fernet-fields
 ddt==1.4.1                # via -r requirements/test.in
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in
@@ -24,7 +24,7 @@ django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
 django==2.2.14            # via -r requirements/base.in, django-fernet-fields, django-model-utils, django-storages, drf-jwt, edx-django-utils, edx-drf-extensions, rest-condition
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via readme-renderer
-drf-jwt==1.16.2           # via edx-drf-extensions
+drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.1.0  # via -r requirements/base.in
 edx-lint==1.5.0           # via -r requirements/quality.in
@@ -53,7 +53,7 @@ pycryptodomex==3.9.8      # via pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pygments==2.6.1           # via readme-renderer
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt
+pyjwt==1.7.1              # via drf-jwt
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,14 +11,14 @@ certifi==2020.6.20        # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via pysrt, requests
 coverage==5.2             # via -r requirements/test.in, pytest-cov
-cryptography==2.9.2       # via django-fernet-fields, pyjwt
+cryptography==2.9.2       # via django-fernet-fields
 ddt==1.4.1                # via -r requirements/test.in
 django-fernet-fields==0.6  # via -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-storages==1.9.1    # via -r requirements/base.in
 django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.16.2           # via edx-drf-extensions
+drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.1.0  # via -r requirements/base.in
 edx-opaque-keys==2.1.0    # via edx-drf-extensions
@@ -39,7 +39,7 @@ py==1.9.0                 # via pytest
 pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt
+pyjwt==1.7.1              # via drf-jwt
 pymongo==3.10.1           # via edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pysrt==1.1.2              # via -r requirements/base.in

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -26,5 +26,5 @@ toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
 tox==3.16.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.9           # via requests
-virtualenv==20.0.25       # via tox
+virtualenv==20.0.26       # via tox
 zipp==1.0.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
latest version drf-jwt==1.16.2 is causing failures in ecom, platform and discovery.
drf-jwt<1.15.0