### PR TITLE
course export with unpublished transcript fix

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -948,6 +948,8 @@ def create_transcript_file(video_id, language_code, file_format, resource_fs, st
             input_format=file_format,
             output_format=Transcript.SRT
         )
+        if not resource_fs.exists(static_dir):
+            resource_fs.makedir(static_dir)
         create_file_in_fs(transcript_content, transcript_filename, resource_fs, static_dir)
 
     return transcript_filename

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '1.4.0'
+VERSION = '1.4.1'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
### [PROD-1128](https://openedx.atlassian.net/browse/PROD-1128)

### Description
Exporting a course while having a video transcript that is yet to be published causes the export to fail. Exporting works fine in case of a published transcript file.

### Fix:
The lack of directories in the file system causes this issue to occur. There is a static subdirectory that needs to be made before creating the transcript file. So if the directory doesn't exist, it must be made in the File System.

### Reviewers
- [x] @DawoudSheraz 
- [ ] @azarembok 

### Post Review
 - [x] Squash & Rebase commit