### PR TITLE
update transcript directory structure during export

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -974,6 +974,19 @@ def create_transcripts_xml(video_id, video_el, resource_fs, static_dir):
     if video_transcripts.exists():
         transcripts_el = SubElement(video_el, 'transcripts')
 
+    # Create static directory based on the file system's subdirectory,
+    # falling back to default path in case of an error
+    try:
+        # File system should not start from /draft directory.
+        static_file_dir = combine(resource_fs._sub_dir.split('/')[1], static_dir)  # pylint: disable=protected-access
+    except KeyError:
+        logger.exception(
+            "VAL Transcript Export: Error creating static directory path for video {} in file system {}".format(
+                video_id, resource_fs
+            )
+        )
+        static_file_dir = combine('course', static_dir)
+
     transcript_files_map = {}
     for video_transcript in video_transcripts:
         language_code = video_transcript.language_code
@@ -985,7 +998,7 @@ def create_transcripts_xml(video_id, video_el, resource_fs, static_dir):
                 language_code=language_code,
                 file_format=file_format,
                 resource_fs=resource_fs.delegate_fs(),
-                static_dir=combine(u'course', static_dir)  # File system should not start from /draft directory.
+                static_dir=static_file_dir
             )
             transcript_files_map[language_code] = transcript_filename
         except TranscriptsGenerationException:

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '1.4.1'
+VERSION = '1.4.2'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
### [TNL-7338](https://openedx.atlassian.net/browse/TNL-7338)

### Description
VAL transcript export in static always expects directory structure to be `course/static`. This is valid for new mongo courses but for old mongo courses, the sub-directory is not `course` but based on the course run. This resulted in export failure for old mongo courses if the transcript was not published. This fix is an enhancement to https://github.com/edx/edx-val/pull/255 which fixes the issue for new courses but not old ones.