### PR TITLE
[SE-3520] Fixes Transcripts Incompletely Uploaded to S3 Bucket

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -1194,7 +1194,7 @@ def import_transcript_from_fs(edx_video_id, language_code, file_name, provider, 
             video_id=edx_video_id,
             language_code=language_code,
             file_format=file_format,
-            content=ContentFile(file_content),
+            content=ContentFile(file_content.encode('utf-8')),
             provider=provider
         )
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '1.4.2'
+VERSION = '1.4.3'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
There's an issue that has been happening when the video transcripts are being uploaded to S3. The video transcripts that get added through _Import Course_ don't end up getting uploaded to the S3 because of the following error:

```bash
S3ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>BadDigest</Code><Message>The Content-MD5 you specified did not match what we received.</Message><ExpectedDigest>819c27ac3c56eaa102afe74e65c197f4</ExpectedDigest><CalculatedDigest>YY0oWmnYyOhDbh5Q7POe8A==</CalculatedDigest><RequestId>B92FCA54F14E6186</RequestId><HostId>Vbx/LS1kB4m7h9Aqcn/hiRAaT4zg7nx4sr/s8EAbTfZJFBxJqtNXCt5j4IQaOHExItVCwrPKcZc=</HostId></Error>
```

Accordingly, this seemed like an existing issue with `boto`, which requires specifying the file encoding.
More context on the issue can be found in the linked discussion, below.

**JIRA tickets**: [OSPR-5084](https://openedx.atlassian.net/browse/OSPR-5084), SE-3520

**Discussions**: https://github.com/boto/boto/issues/2868

**Installation instructions**:

1. Change the user to the `edxapp` user, by `sudo -Hu edxapp bash`.
2. Install the branch by using the one liner shown below.
3. Restart `cms` or all services.
```bash
cd && . edxapp_env && . venvs/edxapp/bin/activate && pip uninstall edxval -y && pip install -e git+https://github.com/open-craft/edx-val.git@nizar/s3_content_md5_mismatch#egg=edxval
```

**Testing instructions**:

> Make sure that your instance uses an S3 Bucket for storage.

1. Install the `edx-val` by following the Installation Instructions.
1. Import a course with a video and a video transcript.
1. Delete the video transcript in the _Edxval > Video Transcripts_
1. Import the course again.
1. View the course and download the transcript.
1. Verify that the transcript is correct. 

> For testing, you can use the Course attached below. The video id in the course attached is `1bb0d9fc-65f0-4b5c-a55b-599ca3c8f425` (will be useful for searching for the video transcript to delete it) 
> 
> [test_course.tar.gz](https://github.com/edx/edx-val/files/5433064/test_course.tar.gz)

**Author notes & concerns**:

1. I noticed that uploading a video with a new transcript, for a video that already exists and a transcript that already exists, does not update the previously existing transcript, [cf these lines](https://github.com/open-craft/edx-val/blob/efa8cc424008ddce9d7c4382900da6a745b35a93/edxval/api.py#L1245-L1255). Could you please provide any explanation as to why that's done like that? (@mushtaqak)

**Reviewers**
- [x] @gabor-boros
- [x] edX reviewer[s] TBD