### PR TITLE
SE-3540 [LX-1653] Fix create_transcripts_xml when resource_fs is WrapFS

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -966,6 +966,9 @@ def create_transcripts_xml(video_id, video_el, resource_fs, static_dir):
         static_dir (str): The Directory to store transcript file.
         resource_fs (SubFS|WrapFS): The file system to store transcripts.
 
+    resource_fs is usually a SubFS, but can be a WrapFS in places like exporting olx through the olx_rest_api.
+    This makes a difference because WrapFS does not have the _sub_dir attribute.
+
     Returns:
         lxml Element object with transcripts information
     """

--- a/edxval/api.py
+++ b/edxval/api.py
@@ -964,7 +964,7 @@ def create_transcripts_xml(video_id, video_el, resource_fs, static_dir):
         video_id (str): Video id of the video.
         video_el (Element): lxml Element object
         static_dir (str): The Directory to store transcript file.
-        resource_fs (SubFS): The file system to store transcripts.
+        resource_fs (SubFS|WrapFS): The file system to store transcripts.
 
     Returns:
         lxml Element object with transcripts information
@@ -974,18 +974,21 @@ def create_transcripts_xml(video_id, video_el, resource_fs, static_dir):
     if video_transcripts.exists():
         transcripts_el = SubElement(video_el, 'transcripts')
 
-    # Create static directory based on the file system's subdirectory,
-    # falling back to default path in case of an error
-    try:
-        # File system should not start from /draft directory.
-        static_file_dir = combine(resource_fs._sub_dir.split('/')[1], static_dir)  # pylint: disable=protected-access
-    except KeyError:
-        logger.exception(
-            "VAL Transcript Export: Error creating static directory path for video {} in file system {}".format(
-                video_id, resource_fs
+    # Note: file system should not start from /draft directory.
+    static_file_dir = combine('course', static_dir)
+    # If we're in a sub directory (ie. a SubFS instead of a WrapFS),
+    # we need to try to base the static file directory on the second path segment,
+    # which will be the course run part for old mongodb key format courses.
+    # See https://openedx.atlassian.net/browse/TNL-7338
+    if hasattr(resource_fs, '_sub_dir'):
+        try:
+            static_file_dir = combine(resource_fs._sub_dir.split('/')[1], static_dir)  # pylint: disable=protected-access
+        except KeyError:
+            logger.exception(
+                "VAL Transcript Export: Error creating static directory path for video {} in file system {}".format(
+                    video_id, resource_fs
+                )
             )
-        )
-        static_file_dir = combine('course', static_dir)
 
     transcript_files_map = {}
     for video_transcript in video_transcripts:

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '1.4.3'
+VERSION = '1.4.4'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
`resource_fs` can be set to a WrapFS instance in some cases,
notably in override_export_fs, which is used when exporting content via
the olx_rest_api.

This bug was introduced in https://github.com/edx/edx-val/pull/258,
which in turn fixed other bugs.
So this commit preserves the behaviour from that PR,
while ensuring that the original static_file_dir logic is used when
a WrapFS is passed (ie. no _sub_dir attr).

An alternate option would be to add AttributeError to an except clause,
but it feels safer to be more specific and proactive in this case.

**JIRA tickets**: [OSPR-5109](https://openedx.atlassian.net/browse/OSPR-5109)

**Merge deadline**: ASAP; this is breaking exporting videos, which is used by our clients.

**Test instructions**:

- ensure that the behaviour from https://github.com/edx/edx-val/pull/258 is retained. @DawoudSheraz, you may wish to check that this PR doesn't undo any of the fixes you did there. Please also check my comments for accuracy. :)  (I don't know how to test the original PR)
- use the olx export rest api to export a video (test with a video with and without transcripts)
- verify that the olx is successfully exported

**Reviewers**:

- [x] @gabor-boros
- [ ] edX reviewer TBD
