### PR TITLE
[SE-3520] Adds waffle flag to enable overriding existing transcripts on import

### DIFF
--- a/edxval/config/waffle.py
+++ b/edxval/config/waffle.py
@@ -1,0 +1,38 @@
+"""
+This module contains various configuration settings via
+waffle switches for edx's video abstraction layer.
+"""
+
+
+from edx_toggles.toggles.__future__ import WaffleFlag
+
+WAFFLE_NAMESPACE = 'edxval'
+
+
+def waffle_name(toggle_name):
+    """
+    Method to append waffle namespace to toggle's name
+
+    Reason behind not using f-strings is backwards compatibility
+    Since this is a method, it should be easy to change later on
+    """
+    return "{namespace}.{toggle_name}".format(
+        namespace=WAFFLE_NAMESPACE,
+        toggle_name=toggle_name,
+    )
+
+
+# .. toggle_name: OVERRIDE_EXISTING_IMPORTED_TRANSCRIPTS
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enables overriding existing transcripts when importing courses with already
+#   existing transcripts. The transcripts are compared using content hashing, and if the transcript
+#   being imported isn't a duplicate, but different in content, it overrides the existing one.
+#   Otherwise, if the transcript is a duplicate, with same content, it doesn't get uploaded.
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2021-01-01
+# .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-5117
+OVERRIDE_EXISTING_IMPORTED_TRANSCRIPTS = WaffleFlag(
+    waffle_name('override_existing_imported_transcripts'),
+    module_name=__name__,
+)

--- a/edxval/settings.py
+++ b/edxval/settings.py
@@ -117,6 +117,7 @@ INSTALLED_APPS = (
     # Third Party
     'rest_framework',
     'storages',
+    'waffle',
 
     # Our App
     'edxval',

--- a/edxval/tests/test_utils.py
+++ b/edxval/tests/test_utils.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""
+Tests the utilities for the Video Abstraction Layer
+"""
+from django.core.files.base import ContentFile
+from django.test import TestCase
+
+from edxval.utils import generate_file_content_hash, is_duplicate_file
+
+
+class UtilityTests(TestCase):
+    """
+    Tests utility methods
+    """
+    def test_generate_file_content_hash(self):
+        """
+        Tests generating file content hash and makes sure the hash returned is
+        64 characters long
+        """
+        file_data = ContentFile('Greetings')
+
+        content_hash = generate_file_content_hash(file_data)
+
+        self.assertEqual(len(content_hash), 64)
+
+    def test_same_content_is_duplicate_file(self):
+        """
+        Tests the `is_duplicate_file` by generating a hash for a content file
+        and then passing the hash and the content to the method to make sure
+        that the 'files' are the same/duplicates.
+        """
+        file_content = 'Greetings'
+
+        file_data = ContentFile(file_content)
+        other_file_data = ContentFile(file_content)
+
+        self.assertTrue(is_duplicate_file(file_data, other_file_data))
+
+    def test_different_content_is_duplicate_file(self):
+        """
+        Tests the `is_duplicate_file` by generating a hash for a content file
+        and then passing the hash and the different file content to the method
+        to make sure that the 'files' are the different.
+        """
+        file_content = 'Greetings'
+        other_file_content = 'Hello there'
+
+        file_data = ContentFile(file_content)
+        other_file_data = ContentFile(other_file_content)
+
+        self.assertFalse(is_duplicate_file(file_data, other_file_data))

--- a/edxval/utils.py
+++ b/edxval/utils.py
@@ -1,7 +1,9 @@
 """
 Util methods to be used in api and models.
 """
+import hashlib
 import json
+from contextlib import closing
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -243,3 +245,40 @@ def validate_generated_images(value, max_items):
         raise ValidationError(u'list must only contain strings.')
 
     return value
+
+
+def generate_file_content_hash(uploaded_file):
+    """
+    Generates SHA256 Content Hash for a File
+
+    Arguments:
+        uploaded_file (UploadedFile): File which will be used for hash generation
+
+    Returns:
+        str sha256 hash
+    """
+    with closing(uploaded_file.open()) as file_data:
+        file_content = file_data.read()
+        if isinstance(file_content, str):
+            file_content = file_content.encode('utf-8')
+
+    content_hash = hashlib.sha256(file_content)
+
+    return content_hash.hexdigest()
+
+
+def is_duplicate_file(uploaded_file_1, uploaded_file_2):
+    """
+    Checks two files to know if they are duplicates by checking content hash
+
+    Arguments:
+        uploaded_file_1 (UploadedFile): File which will be compared to the second file
+        uploaded_file_2 (UploadedFile): File which will be compared to the first file
+
+    Returns:
+        if file is duplicate (boolean)
+    """
+    uploaded_file_1_hash = generate_file_content_hash(uploaded_file_1)
+    uploaded_file_2_hash = generate_file_content_hash(uploaded_file_2)
+
+    return uploaded_file_1_hash == uploaded_file_2_hash

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,5 +8,6 @@ django-fernet-fields
 django-model-utils
 django-storages
 edx-drf-extensions
+edx-toggles
 lxml
 pysrt

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,3 +15,7 @@ djangorestframework==3.9.4
 
 # zipp 2.0.0 requires Python >= 3.6
 zipp==1.0.0
+
+# edx-toggles is set to 1.2.2 because we need `edx_toggles.toggles.__future__`
+# we also expect v2.0.0 to introduce breaking changes in the feature toggle API
+edx-toggles==1.2.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -31,8 +31,11 @@ click-log==0.3.2
 click==7.1.2
     # via
     #   click-log
+    #   code-annotations
     #   edx-lint
     #   pip-tools
+code-annotations==0.10.2
+    # via edx-toggles
 coverage==5.3.1
     # via
     #   -r requirements/test.in
@@ -51,7 +54,9 @@ diff-cover==4.0.1
 distlib==0.3.1
     # via virtualenv
 django-crum==0.7.9
-    # via edx-django-utils
+    # via
+    #   edx-django-utils
+    #   edx-toggles
 django-fernet-fields==0.6
     # via -r requirements/base.in
 django-model-utils==4.1.1
@@ -62,9 +67,11 @@ django-waffle==2.0.0
     # via
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django==2.2.17
     # via
     #   -r requirements/base.in
+    #   code-annotations
     #   django-crum
     #   django-fernet-fields
     #   django-model-utils
@@ -72,6 +79,7 @@ django==2.2.17
     #   drf-jwt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
     #   rest-condition
 djangorestframework==3.9.4
     # via
@@ -86,13 +94,19 @@ docutils==0.16
 drf-jwt==1.17.3
     # via edx-drf-extensions
 edx-django-utils==3.13.0
-    # via edx-drf-extensions
+    # via
+    #   edx-drf-extensions
+    #   edx-toggles
 edx-drf-extensions==6.2.0
     # via -r requirements/base.in
 edx-lint==1.6
     # via -r requirements/quality.in
 edx-opaque-keys==2.1.1
     # via edx-drf-extensions
+edx-toggles==1.2.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 filelock==3.0.12
     # via
     #   tox
@@ -124,6 +138,7 @@ jinja2-pluralize==0.3.0
     # via diff-cover
 jinja2==2.11.2
     # via
+    #   code-annotations
     #   diff-cover
     #   jinja2-pluralize
 lazy-object-proxy==1.4.3
@@ -210,10 +225,14 @@ pytest==6.1.2
     #   pytest-django
 python-dateutil==2.8.1
     # via edx-drf-extensions
+python-slugify==4.0.1
+    # via code-annotations
 pytz==2020.5
     # via
     #   django
     #   fs
+pyyaml==5.3.1
+    # via code-annotations
 readme-renderer==28.0
     # via twine
 requests-toolbelt==0.9.1
@@ -256,8 +275,11 @@ sqlparse==0.4.1
     # via django
 stevedore==1.32.0
     # via
+    #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
+text-unidecode==1.3
+    # via python-slugify
 toml==0.10.2
     # via
     #   pylint

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -29,7 +29,10 @@ click-log==0.3.2
 click==7.1.2
     # via
     #   click-log
+    #   code-annotations
     #   edx-lint
+code-annotations==0.10.2
+    # via edx-toggles
 coverage==5.3.1
     # via
     #   -r requirements/test.in
@@ -41,7 +44,9 @@ cryptography==3.2.1
 ddt==1.4.1
     # via -r requirements/test.in
 django-crum==0.7.9
-    # via edx-django-utils
+    # via
+    #   edx-django-utils
+    #   edx-toggles
 django-fernet-fields==0.6
     # via -r requirements/base.in
 django-model-utils==4.1.1
@@ -52,9 +57,11 @@ django-waffle==2.0.0
     # via
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django==2.2.17
     # via
     #   -r requirements/base.in
+    #   code-annotations
     #   django-crum
     #   django-fernet-fields
     #   django-model-utils
@@ -62,6 +69,7 @@ django==2.2.17
     #   drf-jwt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
     #   rest-condition
 djangorestframework==3.9.4
     # via
@@ -74,13 +82,19 @@ docutils==0.16
 drf-jwt==1.17.3
     # via edx-drf-extensions
 edx-django-utils==3.13.0
-    # via edx-drf-extensions
+    # via
+    #   edx-drf-extensions
+    #   edx-toggles
 edx-drf-extensions==6.2.0
     # via -r requirements/base.in
 edx-lint==1.6
     # via -r requirements/quality.in
 edx-opaque-keys==2.1.1
     # via edx-drf-extensions
+edx-toggles==1.2.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 fs==2.4.11
     # via -r requirements/test.in
 future==0.18.2
@@ -97,10 +111,14 @@ isort==4.3.21
     # via
     #   -r requirements/quality.in
     #   pylint
+jinja2==2.11.2
+    # via code-annotations
 lazy-object-proxy==1.4.3
     # via astroid
 lxml==4.6.2
     # via -r requirements/base.in
+markupsafe==1.1.1
+    # via jinja2
 mccabe==0.6.1
     # via pylint
 mock==3.0.5
@@ -169,10 +187,14 @@ pytest==6.1.2
     #   pytest-django
 python-dateutil==2.8.1
     # via edx-drf-extensions
+python-slugify==4.0.1
+    # via code-annotations
 pytz==2020.5
     # via
     #   django
     #   fs
+pyyaml==5.3.1
+    # via code-annotations
 readme-renderer==28.0
     # via twine
 requests-toolbelt==0.9.1
@@ -212,8 +234,11 @@ sqlparse==0.4.1
     # via django
 stevedore==1.32.0
     # via
+    #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
+text-unidecode==1.3
+    # via python-slugify
 toml==0.10.2
     # via
     #   pylint

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,6 +18,10 @@ chardet==4.0.0
     # via
     #   pysrt
     #   requests
+click==7.1.2
+    # via code-annotations
+code-annotations==0.10.2
+    # via edx-toggles
 coverage==5.3.1
     # via
     #   -r requirements/test.in
@@ -29,7 +33,9 @@ cryptography==3.2.1
 ddt==1.4.1
     # via -r requirements/test.in
 django-crum==0.7.9
-    # via edx-django-utils
+    # via
+    #   edx-django-utils
+    #   edx-toggles
 django-fernet-fields==0.6
     # via -r requirements/base.in
 django-model-utils==4.1.1
@@ -40,8 +46,10 @@ django-waffle==2.0.0
     # via
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
     # via
     #   -r requirements/base.in
+    #   code-annotations
     #   django-crum
     #   django-fernet-fields
     #   django-model-utils
@@ -49,6 +57,7 @@ django-waffle==2.0.0
     #   drf-jwt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
     #   rest-condition
 djangorestframework==3.9.4
     # via
@@ -59,11 +68,17 @@ djangorestframework==3.9.4
 drf-jwt==1.17.3
     # via edx-drf-extensions
 edx-django-utils==3.13.0
-    # via edx-drf-extensions
+    # via
+    #   edx-drf-extensions
+    #   edx-toggles
 edx-drf-extensions==6.2.0
     # via -r requirements/base.in
 edx-opaque-keys==2.1.1
     # via edx-drf-extensions
+edx-toggles==1.2.2
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 fs==2.4.11
     # via -r requirements/test.in
 future==0.18.2
@@ -76,8 +91,12 @@ importlib-metadata==2.1.1
     #   pytest
 iniconfig==1.1.1
     # via pytest
+jinja2==2.11.2
+    # via code-annotations
 lxml==4.6.2
     # via -r requirements/base.in
+markupsafe==1.1.1
+    # via jinja2
 mock==3.0.5
     # via -r requirements/test.in
 more-itertools==8.6.0
@@ -120,10 +139,14 @@ pytest==6.1.2
     #   pytest-django
 python-dateutil==2.8.1
     # via edx-drf-extensions
+python-slugify==4.0.1
+    # via code-annotations
 pytz==2020.5
     # via
     #   django
     #   fs
+pyyaml==5.3.1
+    # via code-annotations
 requests==2.25.1
     # via
     #   edx-drf-extensions
@@ -151,8 +174,11 @@ sqlparse==0.4.1
     # via django
 stevedore==1.32.0
     # via
+    #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
+text-unidecode==1.3
+    # via python-slugify
 toml==0.10.2
     # via pytest
 typing==3.7.4.3

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from setuptools import setup
 
 PACKAGES = [
     'edxval',
+    'edxval.config',
     'edxval.migrations',
     'edxval.tests',
 ]
@@ -46,7 +47,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '1.4.4'
+VERSION = '1.4.5'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
This pull-request is a follow up pull request, related to [this comment from a previous pull-request](https://github.com/edx/edx-val/pull/266#issuecomment-717822495).

Every time we import a new transcript, the existing and the new transcripts are compared by computing their content hash and comparing it.
This helps us identify whether the transcript uploaded is a duplicate of an already existing transcript, or if it is a different transcript that is being uploaded even though a transcript for the same video already exists.

Previously, if a video transcript for a specific video already exists, the new transcript wouldn't get uploaded. Now, if the transcript is different than the already existing one for a certain video, it does get uploaded and overrides it.

**JIRA tickets**: SE-3520, [OSPR-5117](https://openedx.atlassian.net/browse/OSPR-5117)

**Discussions**: [GitHub comment on previous pull-request](https://github.com/edx/edx-val/pull/266#issuecomment-717822495)

**Sandbox URL**:
- LMS: https://edxval-pr268.sandbox.opencraft.hosting/
- Studio: https://studio.edxval-pr268.sandbox.opencraft.hosting/

**Installation Instructions**:

- Install using:
```python
pip install --upgrade git+https://github.com/open-craft/edx-val.git@nizar/overriding_existing_non_duplicate_transcripts#egg=edxval
```

- Apply migrations to LMS
```bash
/edx/bin/edxapp-migrate-lms
```


**Testing instructions**:

- Testing using the Sandbox
    1. Login to the sandbox with `staff`/`edx`.
    1. Go to _Django Admin -> Waffle (django-waffle) -> Flag_ and activate the `edxval.override_existing_imported_transcripts` flag.
    1. Go to Studio and create a new course.
    1. Import one of the courses exported and attached below.
    1. Open the only unit in the course, edit the video, and download the transcript.
    1. Now import the other course, please.
    1. Open the only unit in the course, edit the video, and download the transcript.
    1. The transcript should be different than the other downloaded on step 4.
- Testing using Makefile
    1. Run `make requirements`
    1. Then run `make test`

> ##### Test Courses to Import
> - [First Course](https://github.com/edx/edx-val/files/5506797/course.rarp5q2h.tar.gz)
> - [Second Course](https://github.com/edx/edx-val/files/5506796/course.o5eu1225.tar.gz)

**Author notes and concerns**:

* The tox tests aren't broken due to my changes, they are broken when it comes to python 38 with django 30. I verified that the same problem is happening right now on `master`. 

**Reviewers**
- [x] @gabor-boros
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_EXTRA_REQUIREMENTS:
  - name: git+https://github.com/open-craft/edx-val.git@nizar/overriding_existing_non_duplicate_transcripts#egg=edxval
```