### PR TITLE
Resolves failing Python 3.8 tox tests by updating djangorestframework

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,7 +11,7 @@
 
 # Constraining this since we haven't handled newer versions of Django Rest Framework
 # and we want to allow edx-platform to update this separately.
-djangorestframework==3.9.4
+djangorestframework==3.12.2
 
 # zipp 2.0.0 requires Python >= 3.6
 zipp==1.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -41,7 +41,7 @@ coverage==5.3.1
     #   -r requirements/test.in
     #   coveralls
     #   pytest-cov
-coveralls==2.2.0
+coveralls==3.0.0
     # via -r requirements/travis.in
 cryptography==3.2.1
     # via
@@ -76,12 +76,13 @@ django==2.2.17
     #   django-fernet-fields
     #   django-model-utils
     #   django-storages
+    #   djangorestframework
     #   drf-jwt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
     #   rest-condition
-djangorestframework==3.9.4
+djangorestframework==3.12.2
     # via
     #   -c requirements/constraints.txt
     #   drf-jwt
@@ -97,7 +98,7 @@ edx-django-utils==3.13.0
     # via
     #   edx-drf-extensions
     #   edx-toggles
-edx-drf-extensions==6.2.0
+edx-drf-extensions==6.3.0
     # via -r requirements/base.in
 edx-lint==1.6
     # via -r requirements/quality.in
@@ -187,7 +188,7 @@ pycryptodomex==3.9.9
     # via pyjwkest
 pydocstyle==5.1.1
     # via -r requirements/quality.in
-pygments==2.7.3
+pygments==2.7.4
     # via
     #   diff-cover
     #   readme-renderer

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -66,12 +66,13 @@ django==2.2.17
     #   django-fernet-fields
     #   django-model-utils
     #   django-storages
+    #   djangorestframework
     #   drf-jwt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
     #   rest-condition
-djangorestframework==3.9.4
+djangorestframework==3.12.2
     # via
     #   -c requirements/constraints.txt
     #   drf-jwt
@@ -85,7 +86,7 @@ edx-django-utils==3.13.0
     # via
     #   edx-drf-extensions
     #   edx-toggles
-edx-drf-extensions==6.2.0
+edx-drf-extensions==6.3.0
     # via -r requirements/base.in
 edx-lint==1.6
     # via -r requirements/quality.in
@@ -151,7 +152,7 @@ pycryptodomex==3.9.9
     # via pyjwkest
 pydocstyle==5.1.1
     # via -r requirements/quality.in
-pygments==2.7.3
+pygments==2.7.4
     # via readme-renderer
 pyjwkest==1.4.2
     # via edx-drf-extensions

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -54,12 +54,13 @@ django-waffle==2.0.0
     #   django-fernet-fields
     #   django-model-utils
     #   django-storages
+    #   djangorestframework
     #   drf-jwt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
     #   rest-condition
-djangorestframework==3.9.4
+djangorestframework==3.12.2
     # via
     #   -c requirements/constraints.txt
     #   drf-jwt
@@ -71,7 +72,7 @@ edx-django-utils==3.13.0
     # via
     #   edx-drf-extensions
     #   edx-toggles
-edx-drf-extensions==6.2.0
+edx-drf-extensions==6.3.0
     # via -r requirements/base.in
 edx-opaque-keys==2.1.1
     # via edx-drf-extensions

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,7 +12,7 @@ chardet==4.0.0
     # via requests
 coverage==5.3.1
     # via coveralls
-coveralls==2.2.0
+coveralls==3.0.0
     # via -r requirements/travis.in
 distlib==0.3.1
     # via virtualenv

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '1.4.5'
+VERSION = '1.4.6'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
The previous django rest framework didn't support django 3.0, so when running the tox tests, it would fail since 'six' was removed from django3.0, which the old djangorestframework was still using

Therefore, by updating djangorestframework and specifying the new constraint to 3.12.2, we keep support for the older versions and provide support for django3.0 and python3.8 in the tox tests

**Testing instructions**:

1. Clone the repository
2. Make sure you have `tox` installed
3. Run `tox` to run the tests

