### PR TITLE
Updates Tox and Travis CI testing and documents the changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,14 @@
 language: python
 
 python:
-  - '3.8'
-env:
-  - TOXENV=quality
-  - TOXENV=django22
-  - TOXENV=django30
-  - TOXENV=django31
-matrix:
-  allow_failures:
-    - python: 3.8
-      env: TOXENV=django31
+  - 3.8
+
 install:
   - pip install -r requirements/travis.txt
+
 script:
-  - tox
+  - make test
+
 after_success: coveralls
 # Set password via "travis encrypt --add deploy.password"; for details, see
 # https://docs.travis-ci.com/user/deployment/pypi
@@ -26,6 +20,5 @@ deploy:
   on:
     tags: true
     python: 3.8
-    condition: $TOXENV = quality
   password:
     secure: JGKw0H2Hl1i3OuJ+54hGX/YImhWe+MvkkeFZDynpBKir8XD+E/fbz2lvvmggIrMsawkE5qlOjK8f4d4LMzwL51Ln0EmuIkhUceXLDihrEymZu97uAWbT5qR55RrfwZk/qaYV8JHAszBD3yLA5VOyDLTiDt9s2ilZDQqQqecX514=

--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,16 @@ requirements: ## install development environment requirements
 	pip install -qr requirements/dev.txt --exists-action w
 	pip-sync requirements/dev.txt requirements/private.*
 
-test: clean ## run tests in the current virtualenv
-	python manage.py test
+test: ## run the tox environment tests for the Python version supported in the virtualenv
+## this checks the python version, and changes it to pyNM
+## then greps the pyNM with the envlist available in tox
+## then runs the envs for that specific python version
+	tox -e $(shell tox -a | grep -i $(shell python -V | awk -F'[= .]'  '{print substr(tolower($$1),1,2) $$2 $$3}') | tr '\n' ',')
 
 diff_cover: test ## find diff lines that need test coverage
 	diff-cover coverage.xml
 
-test-all: ## run tests on every supported Python/Django combination
-	tox -e quality
+test-all: ## run all the tox environment tests specified in the tox config
 	tox
 
 validate: quality test ## run tests and quality checks

--- a/README.rst
+++ b/README.rst
@@ -42,9 +42,93 @@ First, create a virtual environment:
     virtualenv venvs/val
     source venvs/val/bin/activate
 
-
-To run tests:
+Second, install the necessary reqiurements:
 
 .. code-block:: bash
 
-    make test
+    make reqiurements
+
+Testing
+-------
+
+Both normal testing and CI builds rely on the tox config for testing. 
+``tox.inu`` is considered the only source of truth, so it should contain all the Python/Django combinations that need to be tested.
+
+This makes updating the tests in the future really simple, because it would just require updating the ``tox.inu`` file with the latest support python version and specific django releases.
+It also provides the freedom for developers to run tests for specific environments with ease. 
+
+Running Tests
+~~~~~~~~~~~~~
+
+=================                   ================================================================================
+``make quality``                    check coding style with pycodestyle and pylint
+``make test``                       run the tox environment tests for the Python version supported in the virtualenv
+``make test-all``                   run all the tox environment tests specified in the tox config
+=================                   ================================================================================
+
+Tox Tests
+~~~~~~~~~
+
+=============================       ================================================================
+``tox -e pyNM-djangoNM-unit``       runs all the unit tests for a specific python and django version
+``tox -e pyNM-quality``             runs all the quality tests for a specific python version
+=============================       ================================================================
+
+Updating Tests
+~~~~~~~~~~~~~~
+
+Different updates to the tests should be done in different areas.
+
+The different testing combinations for Python/Django versions should only be updated in tox.
+
+The travis ci config will only specify which specific python versions should be tested with the changes.
+
+~~~~~~~~~
+Tox Tests
+~~~~~~~~~
+
+Updating the tests will require specifying the Python/Django combination in the ``tox.inu`` file.
+
+The ``[tox]envlist`` and the django ``[django]deps`` should contain all the Python/Django combinations that should be tested for the support Python versions.
+Those are the only two fields that would require editting when testing new Python/Django releases.
+
+For example, if testing Python 3.5 with Django 2.2 would require adding the following:
+
+.. code-block:: tox
+
+    [tox]
+    envlist =
+        py35-django{22}-unit
+        py35-quality
+
+    [django]
+    deps =
+        django22: Django>=2.2,<2.3
+
+Meanwhile, supporting both Python 3.5 with Django 2.2 and Python 3.8 with both Django 2.2 and Django 3.0, would require adding the following instead:
+
+.. code-block:: tox
+
+    [tox]
+    envlist =
+        py35-django{22}-unit
+        py35-quality
+        py38-django{22,30}-unit
+        py38-quality
+
+    [django]
+    deps =
+        django22: Django>=2.2,<2.3
+        django30: Django>=3.0,<3.1
+
+~~~~~~~~~
+Travis CI
+~~~~~~~~~
+
+Supporting new python releases in travis ci would only require adding the version to the list of python versions specified in the configuration file:
+
+.. code-block:: yaml
+
+    python:
+      - 3.5
+      - 3.8

--- a/edxval/models.py
+++ b/edxval/models.py
@@ -362,7 +362,7 @@ class VideoImage(TimeStampedModel):
         Return image url for a course video image.
         """
         storage = get_video_image_storage()
-        return storage.url(self.image.name)
+        return storage.url(self.image.name).strip('/')
 
     def __str__(self):
         """
@@ -554,7 +554,7 @@ class VideoTranscript(TimeStampedModel):
         Returns language transcript url for a particular language.
         """
         storage = get_video_transcript_storage()
-        return storage.url(self.transcript.name)
+        return storage.url(self.transcript.name).strip('/')
 
     def __str__(self):
         return f'{self.language_code} Transcript for {self.video.edx_video_id}'

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
 deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
-	django31: Django>=3.1,<3.2
+    django31: Django>=3.1,<3.2
 
 [unit]
 deps =
@@ -19,7 +19,7 @@ commands =
 
 [quality]
 deps =
-	-r{toxinidir}/requirements/quality.txt
+    -r{toxinidir}/requirements/quality.txt
 commands =
     pylint edxval
     pycodestyle edxval

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,42 @@
 [tox]
-envlist =  py38-django{22,30,31}, quality
+envlist =
+    py38-django{22,30,31}-unit
+    py38-quality
 
-[testenv]
+[django]
 deps =
-	django22: Django>=2.2,<2.3
-	django30: Django>=3.0,<3.1
+    django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
 	django31: Django>=3.1,<3.2
-	-r{toxinidir}/requirements/test.txt
-commands =
-	python -Wd -m pytest {posargs}
 
-[testenv:quality]
-basepython = python3.8
-whitelist_externals =
-	make
+[unit]
+deps =
+    {[django]deps}
+    -r{toxinidir}/requirements/test.txt
+commands =
+    make clean
+    python -Wd -m pytest {posargs}
+
+[quality]
 deps =
 	-r{toxinidir}/requirements/quality.txt
 commands =
-	pylint edxval
-	pycodestyle edxval
-	pydocstyle edxval
-	isort --check-only edxval manage.py setup.py
-	make selfcheck
-	python setup.py sdist bdist_wheel
-	twine check dist/*
+    pylint edxval
+    pycodestyle edxval
+    pydocstyle edxval
+    isort --check-only edxval manage.py setup.py
+    make selfcheck
+    python setup.py sdist bdist_wheel
+    twine check dist/*
 
+[testenv]
+passenv =
+    *
+whitelist_externals =
+    make
+deps =
+    unit: {[unit]deps}
+    quality: {[quality]deps}
+commands =
+    unit: {[unit]commands}
+    quality: {[quality]commands}


### PR DESCRIPTION
This changes removes the awareness of the travis ci's configuration about the different tox testing environments. This is done by making the tox configuration solely responsible for storing the different environments that should be run for a specific python/django combination.

In addition, the updated test command in the Makefile makes it easy to automate running the tox environments which are specific to the existent python version.

This also makes it easy for developers to run all important tox testing environments, which would already be specified there.

Not to mention, this makes it much simpler to update automated tests using the tox configuration, without exerting a lot of effort on the travis ci configuration, which only requires now the python version.

**Discussions**: #275 

**Testing instructions**:

1. Run: `make test-all`
1. Create _virtualenv_ for Python 3.8 and run: `make test`
1. Run: `tox -e py35-django22-unit`
1. Check the Travis CI builds in the pull request