### PR TITLE
fix: upgrade usage of edx_toggles.toggles

### DIFF
--- a/edxval/config/waffle.py
+++ b/edxval/config/waffle.py
@@ -4,7 +4,7 @@ waffle switches for edx's video abstraction layer.
 """
 
 
-from edx_toggles.toggles.__future__ import WaffleFlag
+from edx_toggles.toggles import WaffleFlag
 
 WAFFLE_NAMESPACE = 'edxval'
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,6 +8,6 @@ django-fernet-fields
 django-model-utils
 django-storages
 edx-drf-extensions
-edx-toggles
+edx-toggles>=2.0.0
 lxml
 pysrt

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,7 +7,3 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
-
-# edx-toggles is set to 1.2.2 because we need `edx_toggles.toggles.__future__`
-# we also expect v2.0.0 to introduce breaking changes in the feature toggle API
-edx-toggles==1.2.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,7 +19,7 @@ code-annotations==0.10.2  # via edx-toggles
 colorama==0.4.4           # via twine
 coverage==5.3.1           # via -r requirements/test.in, coveralls, pytest-cov
 coveralls==3.0.0          # via -r requirements/travis.in
-cryptography==3.3.1       # via django-fernet-fields, pyjwt
+cryptography==3.3.1       # via django-fernet-fields, pyjwt, secretstorage
 ddt==1.4.1                # via -r requirements/test.in
 diff-cover==4.1.1         # via -r requirements/dev.in
 distlib==0.3.1            # via virtualenv
@@ -37,7 +37,7 @@ edx-django-utils==3.13.0  # via edx-drf-extensions, edx-toggles
 edx-drf-extensions==6.3.0  # via -r requirements/base.in
 edx-lint==1.6             # via -r requirements/quality.in
 edx-opaque-keys==2.1.1    # via edx-drf-extensions
-edx-toggles==1.2.2        # via -c requirements/constraints.txt, -r requirements/base.in
+edx-toggles==3.1.0        # via -r requirements/base.in
 filelock==3.0.12          # via tox, virtualenv
 fs==2.4.12                # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
@@ -45,6 +45,7 @@ idna==2.10                # via requests
 inflect==5.0.2            # via jinja2-pluralize
 iniconfig==1.1.1          # via pytest
 isort==5.7.0              # via -r requirements/quality.in, pylint
+jeepney==0.6.0            # via keyring, secretstorage
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via code-annotations, diff-cover, jinja2-pluralize
 keyring==21.8.0           # via twine
@@ -88,6 +89,7 @@ requests==2.25.1          # via coveralls, edx-drf-extensions, pyjwkest, request
 responses==0.12.1         # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 rfc3986==1.4.0            # via twine
+secretstorage==3.3.0      # via keyring
 semantic-version==2.8.5   # via edx-drf-extensions
 six==1.15.0               # via astroid, bleach, cryptography, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, pyjwkest, python-dateutil, readme-renderer, responses, tox, virtualenv
 snowballstemmer==2.0.0    # via pydocstyle

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -18,7 +18,7 @@ click==7.1.2              # via click-log, code-annotations, edx-lint
 code-annotations==0.10.2  # via edx-toggles
 colorama==0.4.4           # via twine
 coverage==5.3.1           # via -r requirements/test.in, pytest-cov
-cryptography==3.3.1       # via django-fernet-fields, pyjwt
+cryptography==3.3.1       # via django-fernet-fields, pyjwt, secretstorage
 ddt==1.4.1                # via -r requirements/test.in
 django-crum==0.7.9        # via edx-django-utils, edx-toggles
 django-fernet-fields==0.6  # via -r requirements/base.in
@@ -33,12 +33,13 @@ edx-django-utils==3.13.0  # via edx-drf-extensions, edx-toggles
 edx-drf-extensions==6.3.0  # via -r requirements/base.in
 edx-lint==1.6             # via -r requirements/quality.in
 edx-opaque-keys==2.1.1    # via edx-drf-extensions
-edx-toggles==1.2.2        # via -c requirements/constraints.txt, -r requirements/base.in
+edx-toggles==3.1.0        # via -r requirements/base.in
 fs==2.4.12                # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 idna==2.10                # via requests
 iniconfig==1.1.1          # via pytest
 isort==5.7.0              # via -r requirements/quality.in, pylint
+jeepney==0.6.0            # via keyring, secretstorage
 jinja2==2.11.2            # via code-annotations
 keyring==21.8.0           # via twine
 lazy-object-proxy==1.4.3  # via astroid
@@ -80,6 +81,7 @@ requests==2.25.1          # via edx-drf-extensions, pyjwkest, requests-toolbelt,
 responses==0.12.1         # via -r requirements/test.in
 rest-condition==1.0.3     # via edx-drf-extensions
 rfc3986==1.4.0            # via twine
+secretstorage==3.3.0      # via keyring
 semantic-version==2.8.5   # via edx-drf-extensions
 six==1.15.0               # via astroid, bleach, cryptography, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, pyjwkest, python-dateutil, readme-renderer, responses
 snowballstemmer==2.0.0    # via pydocstyle

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,7 +26,7 @@ drf-jwt==1.17.3           # via edx-drf-extensions
 edx-django-utils==3.13.0  # via edx-drf-extensions, edx-toggles
 edx-drf-extensions==6.3.0  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via edx-drf-extensions
-edx-toggles==1.2.2        # via -c requirements/constraints.txt, -r requirements/base.in
+edx-toggles==3.1.0        # via -r requirements/base.in
 fs==2.4.12                # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 idna==2.10                # via requests

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '2.0.0'
+VERSION = '2.0.1'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
The waffle classes previously in future are now available directly from
edx_toggles.toggles. Since this future module is going to be removed soon,
we become future-proof by getting rid of it.

cc @robrap 