### PR TITLE
fix: allow conversion of Latin-1 encoded transcripts.

### DIFF
--- a/edxval/tests/test_transcript_utils.py
+++ b/edxval/tests/test_transcript_utils.py
@@ -94,3 +94,19 @@ class TestTranscriptUtils(TestCase):
         invalid_srt_transcript = b'invalid SubRip file content'
         with self.assertRaises(TranscriptsGenerationException):
             Transcript.convert(invalid_srt_transcript, 'srt', 'sjson')
+
+    def test_convert_latin1(self):
+        """
+        Test that we fall back to Latin-1 if the content is not proper Unicode.
+        """
+        latin1_srt_transcript = textwrap.dedent("""\
+            0
+            00:00:10,500 --> 00:00:13,000
+            éléphant's Dream
+
+            1
+            00:00:15,000 --> 00:00:18,000
+            At the left we can see...
+
+        """).encode('latin-1')
+        Transcript.convert(latin1_srt_transcript, 'srt', 'sjson')

--- a/edxval/transcript_utils.py
+++ b/edxval/transcript_utils.py
@@ -94,7 +94,12 @@ class Transcript:
 
         # Decode the content with utf-8-sig which will also
         # skip byte order mark(BOM) character if found.
-        content = content.decode('utf-8-sig')
+        try:
+            content = content.decode('utf-8-sig')
+        except UnicodeDecodeError:
+            # Most of our stuff is UTF-8, but don't break if Latin-1 encoded
+            # transcripts are still floating around in older courses.
+            content = content.decode('latin-1')
 
         if input_format == output_format:
             return content

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '2.0.2'
+VERSION = '2.0.3'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
```
﻿We try to always encode transcripts in UTF-8, but we have Latin-1
encoded files in older courses. So we have to fall back to that
when we get a UnicodeDecodeError (This is one of the causes of
export failures in TNL-8007.)
```
