### PR TITLE
feat: integrate pact broker

### DIFF
--- a/edxval/management/commands/verify_pact.py
+++ b/edxval/management/commands/verify_pact.py
@@ -22,20 +22,32 @@ class Command(BaseCommand):
     """
     help = "Verify the VAL provider pacts"
 
+    default_opts = {
+            'broker_url': getattr(settings, 'PACT_BROKER_BASE_URL', None),
+            'publish_version': '1',
+            'publish_verification_results': getattr(settings, 'PUBLISH_VERIFICATION_RESULTS', False)
+        }
+
     def verify_pact(self):
         """
         Verify the pacts with Pact-verifier.
         """
-        # TODO: Use pact broker to get the pacts that specify VAL as the provider
         verifier = Verifier(
             provider='VAL',
             provider_base_url=settings.PROVIDER_BASE_URL
+        )
 
-        )
-        verifier.verify_pacts(
-            'edxval/pacts/vem-val.json',
-            provider_states_setup_url=settings.PROVIDER_STATES_URL,
-        )
+        if self.default_opts['broker_url']:
+            verifier.verify_with_broker(
+                **self.default_opts,
+                verbose=False,
+                provider_states_setup_url=settings.PROVIDER_STATES_URL,
+            )
+        else:
+            verifier.verify_pacts(
+                'edxval/pacts/vem-val.json',
+                provider_states_setup_url=settings.PROVIDER_STATES_URL,
+            )
 
     def handle(self, *args, **options):
         log.info("Starting pact verification")

--- a/edxval/settings/test.py
+++ b/edxval/settings/test.py
@@ -17,3 +17,13 @@ DATABASES = {
 TEST_ONLY_URLS = True
 PROVIDER_BASE_URL = 'http://127.0.0.1:8000'
 PROVIDER_STATES_URL = '{}/edxval/pact/provider_states/'.format(PROVIDER_BASE_URL)
+
+# PACT BROKER
+
+# if env variables are in place
+# import os
+# PACT_BROKER_BASE_URL = os.environ.get('PACT_BROKER_BASE_URL', None)
+# PACT_BROKER_BASE_URL = os.environ.get('PUBLISH_VERIFICATION_RESULTS', False)
+
+PACT_BROKER_BASE_URL = 'http://localhost:9292'
+PUBLISH_VERIFICATION_RESULTS = True


### PR DESCRIPTION
### [PROD-2347](https://openedx.atlassian.net/browse/PROD-2347)

### Description
This PR integrates pact-broker into edx-val so that pacts can be fetched via broker and verification results can be sent back to broker. Broker is currently been setup in here edx/video-encode-manager#244

### Testing
Since pact testing is not running in any pipeline by default therefore flags and env variables are directly written into test settings. 

### Linked Issue:
Publish verification flag is setup but currently not working due this reason pact-foundation/pact-python#221