### PR TITLE
feat: add default auth middleware for pact verification

### DIFF
--- a/edxval/management/commands/README.md
+++ b/edxval/management/commands/README.md
@@ -1,0 +1,9 @@
+### Description
+
+verify_pact.py is the management command for the provider pact verification. It will be used to verify the pacts for which edx-val is the provider.
+Since pact provider verification requires a provider url where the interactions will be made, the server should be running before 
+executing the management command. Therefore,
+
+1. Run ``python manage.py migrate --settings=edxval.settings.test`` to run the migrations for test database. This will be one-time step for local testing, unless DB structure is changed that will affect Pact verification.
+2. Run ``python manage.py runserver --settings=edxval.settings.test`` to start the server against which Pact provider verification will take place.
+3. Run ``python manage.py verify_pact --settings=edxval.settings.test`` in another terminal to start the pact verification process.

--- a/edxval/pacts/middleware.py
+++ b/edxval/pacts/middleware.py
@@ -1,0 +1,33 @@
+"""
+Contain the middleware logic needed during pact verification
+"""
+from django.contrib import auth
+from django.utils.deprecation import MiddlewareMixin
+
+User = auth.get_user_model()
+
+
+class AuthenticationMiddleware(MiddlewareMixin):
+    """
+    Middleware to add default authentication into the requests for pact verification.
+
+    This middleware is required to add a default authenticated user and bypass CSRF validation
+    into the requests during the pact verification workflow. Without the authentication, the pact verification
+    process will not work as the apis.
+    See https://docs.pact.io/faq#how-do-i-test-oauth-or-other-security-headers
+    """
+    VIEWS_LIST = ['VideoDetail', 'VideoStatusView', 'VideoImagesView', 'VideoTranscriptView']
+
+    def __init__(self, get_response):
+        super().__init__()
+        self.auth_user = User.objects.get_or_create(username='edx', is_staff=True)[0]
+        self.get_response = get_response
+
+    def process_view(self, request, view_func, view_args, view_kwargs):  # pylint: disable=unused-argument
+        """
+        Add a default authenticated user and remove CSRF checks for a request
+        in a subset of views.
+        """
+        if view_func.__name__ in self.VIEWS_LIST and request.user.is_anonymous:
+            request.user = self.auth_user
+            request._dont_enforce_csrf_checks = True  # pylint: disable=protected-access

--- a/edxval/pacts/utils.py
+++ b/edxval/pacts/utils.py
@@ -4,7 +4,6 @@ Utility methods needed during pact verification.
 
 from edxval.models import CourseVideo, EncodedVideo, Profile, Video, VideoImage, VideoTranscript
 from edxval.tests import constants
-from edxval.views import VideoDetail, VideoImagesView, VideoStatusView, VideoTranscriptView
 
 VIDEO_ID = "3386eda1-8d6e-439d-tb89-e90a5c52h103"
 COURSE_ID = "course-v1:testX+test123+2030"
@@ -24,66 +23,18 @@ def clear_database():
     VideoTranscript.objects.filter(video__edx_video_id=VIDEO_ID).delete()
 
 
-def setup_successful_video_status_state():
-    """
-    Setup provider state for a successful video status update.
-    """
-    remove_view_auth_and_perms(VideoStatusView)
-    create_video()
-
-
-def setup_unsuccessful_video_status_state():
-    """
-    Setup the provider state for unsuccessful video status update.
-    """
-    remove_view_auth_and_perms(VideoStatusView)
-
-
-def setup_successful_video_image_state():
-    """
-    Setup the provider state for successful video image update.
-    """
-    remove_view_auth_and_perms(VideoImagesView)
-    create_course_video()
-    create_profiles()
-
-
-def setup_unsuccessful_video_image_state():
-    """
-    Setup the provider state for unsuccessful video image update.
-    """
-    remove_view_auth_and_perms(VideoImagesView)
-
-
 def setup_successful_video_details_state():
     """
     Setup the provider state for successful video details update call.
     """
-    remove_view_auth_and_perms(VideoDetail)
     create_course_video()
     create_profiles()
-
-
-def setup_unsuccessful_video_details_state():
-    """
-    Setup the provider state for unsuccessful video details update call.
-    """
-    remove_view_auth_and_perms(VideoDetail)
-
-
-def setup_successful_video_transcripts_state():
-    """
-    Setup the provider state for successful video transcripts update call.
-    """
-    remove_view_auth_and_perms(VideoTranscriptView)
-    create_video()
 
 
 def setup_unsuccessful_video_transcripts_state():
     """
     Setup the provider state for unsuccessful video transcripts update call.
     """
-    remove_view_auth_and_perms(VideoTranscriptView)
     video = create_video()
     VideoTranscript.objects.create(video=video, language_code='en', provider='3PlayMedia', file_format='sjson')
 
@@ -112,18 +63,3 @@ def create_course_video():
     """
     video = create_video()
     return CourseVideo.objects.create(course_id=COURSE_ID, video=video)
-
-
-def remove_view_auth_and_perms(view):
-    """
-    Temporarily remove authentication and permissions from the given view
-    that pact needs to verify the contract and return the details of original auth
-    and permissions of each view in a dict.
-
-    OAuth and Security headers usually prevent the pact verifier from successfully
-    verifying the pact. There isn't a documented way to add the authentication headers in pact-python.
-    Pact official documentation suggests creating mock auth or relaxing auth for pact verification.
-    See https://docs.pact.io/faq#how-do-i-test-oauth-or-other-security-headers
-    """
-    view.authentication_classes = []
-    view.permission_classes = []

--- a/edxval/pacts/vem-val.json
+++ b/edxval/pacts/vem-val.json
@@ -7,27 +7,6 @@
   },
   "interactions": [
     {
-      "description": "A request for oauth token",
-      "request": {
-        "method": "post",
-        "path": "/oauth2/access_token"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-        },
-        "body": {
-          "access_token": "token",
-          "expires_in": 1
-        },
-        "matchingRules": {
-          "$.body.expires_in": {
-            "match": "type"
-          }
-        }
-      }
-    },
-    {
       "description": "A request for video transcript creation for a given provider and language",
       "providerState": "A valid video with no video transcript information exists",
       "request": {
@@ -159,7 +138,7 @@
               "bitrate": 1,
               "profile": "hls",
               "created": "2021-01-01T00:00:00",
-              "modified": "2021-04-13T12:11:48.045287"
+              "modified": "2021-04-14T12:19:47.883503"
             },
             {
               "url": "string",
@@ -167,7 +146,7 @@
               "bitrate": 1,
               "profile": "hls",
               "created": "2021-01-01T00:00:00",
-              "modified": "2021-04-13T12:11:48.045287"
+              "modified": "2021-04-14T12:19:47.883503"
             },
             {
               "url": "string",
@@ -175,7 +154,7 @@
               "bitrate": 1,
               "profile": "hls",
               "created": "2021-01-01T00:00:00",
-              "modified": "2021-04-13T12:11:48.045287"
+              "modified": "2021-04-14T12:19:47.883503"
             },
             {
               "url": "string",
@@ -183,7 +162,7 @@
               "bitrate": 1,
               "profile": "hls",
               "created": "2021-01-01T00:00:00",
-              "modified": "2021-04-13T12:11:48.045287"
+              "modified": "2021-04-14T12:19:47.883503"
             }
           ],
           "courses": [

--- a/edxval/pacts/views.py
+++ b/edxval/pacts/views.py
@@ -9,13 +9,9 @@ from django.views.decorators.http import require_POST
 
 from edxval.pacts.utils import (
     clear_database,
+    create_course_video,
+    create_video,
     setup_successful_video_details_state,
-    setup_successful_video_image_state,
-    setup_successful_video_status_state,
-    setup_successful_video_transcripts_state,
-    setup_unsuccessful_video_details_state,
-    setup_unsuccessful_video_image_state,
-    setup_unsuccessful_video_status_state,
     setup_unsuccessful_video_transcripts_state,
 )
 
@@ -27,14 +23,11 @@ def provider_state(request):
     Provider state setup view needed by pact verifier.
     """
     state_setup_mapping = {
-        'A valid video_id video exists': setup_successful_video_status_state,
+        'A valid video_id video exists': create_video,
         'A valid video with no details exists': setup_successful_video_details_state,
-        'A valid video with no image information exists': setup_successful_video_image_state,
-        'A valid video with no video transcript information exists': setup_successful_video_transcripts_state,
+        'A valid video with no image information exists': create_course_video,
+        'A valid video with no video transcript information exists': create_video,
         'A valid video and video transcript information exists': setup_unsuccessful_video_transcripts_state,
-        'No video and video details exist': setup_unsuccessful_video_details_state,
-        'No valid video with video images details exist': setup_unsuccessful_video_image_state,
-        'A video against given video id does not exist': setup_unsuccessful_video_status_state,
     }
     request_body = json.loads(request.body)
     state = request_body.get('state')

--- a/edxval/pacts/views.py
+++ b/edxval/pacts/views.py
@@ -31,8 +31,8 @@ def provider_state(request):
     }
     request_body = json.loads(request.body)
     state = request_body.get('state')
+    clear_database()
     if state in state_setup_mapping:
         print('Setting up provider state for state value: {}'.format(state))
-        clear_database()
         state_setup_mapping[state]()
     return JsonResponse({'result': state})

--- a/edxval/settings/test.py
+++ b/edxval/settings/test.py
@@ -28,25 +28,5 @@ PROVIDER_STATES_URL = '{}/edxval/pact/provider_states/'.format(PROVIDER_BASE_URL
 PACT_BROKER_BASE_URL = 'http://localhost:9292'
 PUBLISH_VERIFICATION_RESULTS = True
 
-JWT_AUTH = {
-    'JWT_AUDIENCE': 'test-aud',
-    'JWT_DECODE_HANDLER': 'edx_rest_framework_extensions.auth.jwt.decoder.jwt_decode_handler',
-    'JWT_ISSUER': 'test-iss',
-    'JWT_LEEWAY': 1,
-    'JWT_SECRET_KEY': 'test-key',
-    'JWT_ALGORITHM': 'HS256',
-    'JWT_SUPPORTED_VERSION': '1.0.0',
-    'JWT_VERIFY_AUDIENCE': True,
-    'JWT_VERIFY_EXPIRATION': True,
-    'JWT_AUTH_HEADER_PREFIX': 'JWT',
-    'JWT_ISSUERS': [
-        {
-            'ISSUER': 'test-issuer-1',
-            'SECRET_KEY': 'test-secret-key',
-            'AUDIENCE': 'test-audience',
-        }
-    ],
-}
 
-MIDDLEWARE = list(MIDDLEWARE) + ['edxval.pacts.middleware.AuthenticationMiddleware']
-MIDDLEWARE = tuple(MIDDLEWARE)
+MIDDLEWARE = MIDDLEWARE + ('edxval.pacts.middleware.AuthenticationMiddleware',)

--- a/edxval/settings/test.py
+++ b/edxval/settings/test.py
@@ -27,3 +27,26 @@ PROVIDER_STATES_URL = '{}/edxval/pact/provider_states/'.format(PROVIDER_BASE_URL
 
 PACT_BROKER_BASE_URL = 'http://localhost:9292'
 PUBLISH_VERIFICATION_RESULTS = True
+
+JWT_AUTH = {
+    'JWT_AUDIENCE': 'test-aud',
+    'JWT_DECODE_HANDLER': 'edx_rest_framework_extensions.auth.jwt.decoder.jwt_decode_handler',
+    'JWT_ISSUER': 'test-iss',
+    'JWT_LEEWAY': 1,
+    'JWT_SECRET_KEY': 'test-key',
+    'JWT_ALGORITHM': 'HS256',
+    'JWT_SUPPORTED_VERSION': '1.0.0',
+    'JWT_VERIFY_AUDIENCE': True,
+    'JWT_VERIFY_EXPIRATION': True,
+    'JWT_AUTH_HEADER_PREFIX': 'JWT',
+    'JWT_ISSUERS': [
+        {
+            'ISSUER': 'test-issuer-1',
+            'SECRET_KEY': 'test-secret-key',
+            'AUDIENCE': 'test-audience',
+        }
+    ],
+}
+
+MIDDLEWARE = list(MIDDLEWARE) + ['edxval.pacts.middleware.AuthenticationMiddleware']
+MIDDLEWARE = tuple(MIDDLEWARE)


### PR DESCRIPTION
### [PROD-2343](https://openedx.atlassian.net/browse/PROD-2343)

### Description
Adds an auth middleware(test-only) that adds authenticated user and bypass csrf for the requests during pact verification.