### PR TITLE
build: move pact-python to test requirements

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,6 +9,5 @@ django-model-utils
 django-storages
 edx-drf-extensions
 edx-toggles>=2.0.0
-pact-python
 lxml
 pysrt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -26,7 +26,7 @@ idna==3.2
     # via requests
 packaging==21.0
     # via tox
-platformdirs==2.2.0
+platformdirs==2.3.0
     # via virtualenv
 pluggy==0.13.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via fs
 asgiref==3.4.1
     # via uvicorn
-astroid==2.7.2
+astroid==2.7.3
     # via
     #   pylint
     #   pylint-celery
@@ -173,7 +173,7 @@ packaging==21.0
     #   pytest
     #   tox
 pact-python==1.4.2
-    # via -r requirements/base.in
+    # via -r requirements/test.in
 pbr==5.6.0
     # via stevedore
 pep517==0.11.0
@@ -182,7 +182,7 @@ pip-tools==6.2.0
     # via -r requirements/dev.in
 pkginfo==1.7.1
     # via twine
-platformdirs==2.2.0
+platformdirs==2.3.0
     # via
     #   pylint
     #   virtualenv
@@ -244,7 +244,7 @@ pytest-cov==2.12.1
     # via -r requirements/test.in
 pytest-django==4.4.0
     # via -r requirements/test.in
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   pytest-cov
     #   pytest-django
@@ -323,7 +323,7 @@ tqdm==4.62.2
     # via twine
 twine==3.4.2
     # via -r requirements/quality.in
-typing-extensions==3.10.0.1
+typing-extensions==3.10.0.2
     # via pydantic
 urllib3==1.26.6
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via fs
 asgiref==3.4.1
     # via uvicorn
-astroid==2.7.2
+astroid==2.7.3
     # via
     #   pylint
     #   pylint-celery
@@ -147,12 +147,12 @@ packaging==21.0
     #   bleach
     #   pytest
 pact-python==1.4.2
-    # via -r requirements/base.in
+    # via -r requirements/test.in
 pbr==5.6.0
     # via stevedore
 pkginfo==1.7.1
     # via twine
-platformdirs==2.2.0
+platformdirs==2.3.0
     # via pylint
 pluggy==0.13.1
     # via
@@ -206,7 +206,7 @@ pytest-cov==2.12.1
     # via -r requirements/test.in
 pytest-django==4.4.0
     # via -r requirements/test.in
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   pytest-cov
     #   pytest-django
@@ -273,7 +273,7 @@ tqdm==4.62.2
     # via twine
 twine==3.4.2
     # via -r requirements/quality.in
-typing-extensions==3.10.0.1
+typing-extensions==3.10.0.2
     # via pydantic
 urllib3==1.26.6
     # via

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,6 +6,7 @@ coverage
 ddt
 fs
 mock
+pact-python
 pytest-cov
 pytest-django
 responses

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -111,7 +111,7 @@ newrelic==6.8.1.164
 packaging==21.0
     # via pytest
 pact-python==1.4.2
-    # via -r requirements/base.in
+    # via -r requirements/test.in
 pbr==5.6.0
     # via stevedore
 pluggy==0.13.1
@@ -146,7 +146,7 @@ pytest-cov==2.12.1
     # via -r requirements/test.in
 pytest-django==4.4.0
     # via -r requirements/test.in
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   pytest-cov
     #   pytest-django
@@ -195,7 +195,7 @@ toml==0.10.2
     # via
     #   pytest
     #   pytest-cov
-typing-extensions==3.10.0.1
+typing-extensions==3.10.0.2
     # via pydantic
 urllib3==1.26.6
     # via

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def load_requirements(*requirements_paths):
     return list(requirements)
 
 
-VERSION = '2.1.0'
+VERSION = '2.1.1'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
### [PROD-2487](https://openedx.atlassian.net/browse/PROD-2487)

### Description
Add pact-python to test requirements only to fix edxval adding pact-python and other depedencies as base requirements in edx-platform. See https://github.com/edx/edx-platform/commit/63635d6bcd33116ad5d5349023c9b5d8fd6bf8b9#diff-10762e1094dbeeaba59c58cec8a91b71b99f2063f7f1f20e5c0e3e635f42b2df