### PR TITLE
test: add provider verification CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,4 +72,4 @@ jobs:
         export PUBLISH_VERSION=`git rev-parse --short HEAD`
         export PUBLISH_TAGS=${{ github.head_ref }}
         export PUBLISH_VERIFICATION_RESULTS=true
-        pytest edxval/pacts/verify_pact.py --ds=edxval.settings.pact
+        pytest -s edxval/pacts/verify_pact.py --ds=edxval.settings.pact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,35 @@ jobs:
       with:
         flags: unittests
         fail_ci_if_error: true
+
+
+  provider-verification:
+    name: Pact Provider Verification
+    runs-on: ubuntu-20.04
+    needs: run_tests
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install pip
+      run: pip install -r requirements/pip.txt
+
+    - name: Install Dependencies
+      run: |
+        pip install -r requirements/ci.txt
+        pip install -r requirements/test.txt
+
+    - name: Verify Pacts
+      run: |
+        export PACT_BROKER_BASE_URL='https://edx.pactflow.io'
+        export PACT_BROKER_TOKEN=${{ secrets.PACT_FLOW_ACCESS_TOKEN }}
+        export PUBLISH_VERSION=`git rev-parse --short HEAD`
+        export PUBLISH_TAGS=${{ github.head_ref }}
+        export PUBLISH_VERIFICATION_RESULTS=true
+        pytest edxval/pacts/verify_pact.py --ds=edxval.settings.pact

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ openassessment/xblock/static/js/fixtures/*.html
 
 # logging
 logs/*/*.log*
+log
 
 # Vagrant
 .vagrant

--- a/edxval/pacts/verify_pact.py
+++ b/edxval/pacts/verify_pact.py
@@ -50,6 +50,7 @@ class ProviderVerificationServer(LiveServerTestCase):
             output, _ = self.verifier.verify_with_broker(
                 **self.PACT_CONFIG,
                 verbose=False,
+                enable_pending=True,
                 provider_states_setup_url=f"{self.live_server_url}{reverse('provider-state-view')}",
             )
         else:

--- a/edxval/pacts/verify_pact.py
+++ b/edxval/pacts/verify_pact.py
@@ -19,7 +19,12 @@ class ProviderVerificationServer(LiveServerTestCase):
 
     PACT_CONFIG = {
         'broker_url': settings.PACT_BROKER_BASE_URL,
-        'publish_version': '1',
+        'consumer_version_selectors': [
+            {'tag': 'production', 'latest': True},
+            {"tag": "master", "latest": True},
+        ],
+        'publish_version': settings.PUBLISH_VERSION,
+        'provider_tags': settings.PUBLISH_TAGS,
         'publish_verification_results': settings.PUBLISH_VERIFICATION_RESULTS,
         'headers': ['Pact-Authentication: AllowAny', ],
     }

--- a/edxval/settings/pact.py
+++ b/edxval/settings/pact.py
@@ -11,5 +11,8 @@ from edxval.settings.test import *  # pylint: disable=wildcard-import
 PUBLISH_VERIFICATION_RESULTS = os.environ.get('PUBLISH_VERIFICATION_RESULTS', 'False').lower() in ('true', 'yes', '1')
 PROVIDER_STATES_SETUP_VIEW_URL = True
 PACT_BROKER_BASE_URL = os.environ.get('PACT_BROKER_BASE_URL', 'http://localhost:9292')
+PUBLISH_VERSION = os.environ.get('PUBLISH_VERSION', '1')
+PUBLISH_TAGS = os.environ.get('PUBLISH_TAGS', 'master')
+PUBLISH_TAGS = [PUBLISH_TAGS, 'production' if PUBLISH_TAGS == 'master' else 'development']
 
 MIDDLEWARE = MIDDLEWARE + ('edxval.pacts.middleware.AuthenticationMiddleware',)

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,33 +4,33 @@
 #
 #    make upgrade
 #
-backports.entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.1
     # via virtualenv
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via requests
-coverage==5.5
+coverage==6.1.1
     # via coveralls
-coveralls==3.2.0
+coveralls==3.3.0
     # via -r requirements/ci.in
 distlib==0.3.3
     # via virtualenv
 docopt==0.6.2
     # via coveralls
-filelock==3.3.0
+filelock==3.3.2
     # via
     #   tox
     #   virtualenv
-idna==3.2
+idna==3.3
     # via requests
-packaging==21.0
+packaging==21.2
     # via tox
 platformdirs==2.4.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
-py==1.10.0
+py==1.11.0
     # via tox
 pyparsing==2.4.7
     # via packaging
@@ -50,5 +50,5 @@ tox-battery==0.6.1
     # via -r requirements/ci.in
 urllib3==1.26.7
     # via requests
-virtualenv==20.8.1
+virtualenv==20.10.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,33 +4,35 @@
 #
 #    make upgrade
 #
+anyio==3.3.4
+    # via starlette
 appdirs==1.4.4
     # via fs
 asgiref==3.4.1
     # via uvicorn
-astroid==2.8.0
+astroid==2.8.4
     # via
     #   pylint
     #   pylint-celery
 attrs==21.2.0
     # via pytest
-backports.entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.1
     # via virtualenv
 bleach==4.1.0
     # via readme-renderer
 boto==2.49.0
     # via -r requirements/base.in
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
-cffi==1.14.6
+cffi==1.15.0
     # via cryptography
 chardet==4.0.0
     # via
     #   diff-cover
     #   pysrt
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via requests
-click==8.0.1
+click==8.0.3
     # via
     #   click-log
     #   code-annotations
@@ -46,21 +48,20 @@ code-annotations==1.2.0
     #   edx-toggles
 colorama==0.4.4
     # via twine
-coverage[toml]==5.5
+coverage[toml]==6.1.1
     # via
     #   -r requirements/test.in
     #   coveralls
     #   pytest-cov
-coveralls==3.2.0
+coveralls==3.3.0
     # via -r requirements/ci.in
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   django-fernet-fields
     #   pyjwt
-    #   secretstorage
-ddt==1.4.3
+ddt==1.4.4
     # via -r requirements/test.in
-diff-cover==6.4.1
+diff-cover==6.4.2
     # via -r requirements/dev.in
 distlib==0.3.3
     # via virtualenv
@@ -77,16 +78,15 @@ django==2.2.24
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-    #   rest-condition
 django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-toggles
 django-fernet-fields==0.6
     # via -r requirements/base.in
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via -r requirements/base.in
-django-storages==1.11.1
+django-storages==1.12.3
     # via -r requirements/base.in
 django-waffle==2.2.1
     # via
@@ -97,30 +97,27 @@ djangorestframework==3.12.4
     # via
     #   drf-jwt
     #   edx-drf-extensions
-    #   rest-condition
 docopt==0.6.2
     # via coveralls
-docutils==0.17.1
+docutils==0.18
     # via readme-renderer
-drf-jwt==1.19.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   edx-drf-extensions
+drf-jwt==1.19.1
+    # via edx-drf-extensions
 edx-django-utils==4.4.0
     # via
     #   edx-drf-extensions
     #   edx-toggles
-edx-drf-extensions==7.0.1
+edx-drf-extensions==8.0.1
     # via -r requirements/base.in
-edx-lint==5.2.0
+edx-lint==5.2.1
     # via -r requirements/quality.in
 edx-opaque-keys==2.2.2
     # via edx-drf-extensions
 edx-toggles==4.2.0
     # via -r requirements/base.in
-fastapi==0.68.1
+fastapi==0.70.0
     # via pact-python
-filelock==3.3.0
+filelock==3.3.2
     # via
     #   tox
     #   virtualenv
@@ -130,9 +127,11 @@ future==0.18.2
     # via pyjwkest
 h11==0.12.0
     # via uvicorn
-idna==3.2
-    # via requests
-importlib-metadata==4.8.1
+idna==3.3
+    # via
+    #   anyio
+    #   requests
+importlib-metadata==4.8.2
     # via
     #   keyring
     #   twine
@@ -140,15 +139,11 @@ inflect==5.3.0
     # via jinja2-pluralize
 iniconfig==1.1.1
     # via pytest
-isort==5.9.3
+isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jeepney==0.7.1
-    # via
-    #   keyring
-    #   secretstorage
-jinja2==3.0.1
+jinja2==3.0.2
     # via
     #   code-annotations
     #   diff-cover
@@ -159,7 +154,7 @@ keyring==23.2.1
     # via twine
 lazy-object-proxy==1.6.0
     # via astroid
-lxml==4.6.3
+lxml==4.6.4
     # via -r requirements/base.in
 markupsafe==2.0.1
     # via jinja2
@@ -167,20 +162,20 @@ mccabe==0.6.1
     # via pylint
 mock==4.0.3
     # via -r requirements/test.in
-newrelic==7.0.0.166
+newrelic==7.2.3.170
     # via edx-django-utils
-packaging==21.0
+packaging==21.2
     # via
     #   bleach
     #   pytest
     #   tox
-pact-python==1.4.4
+pact-python==1.4.5
     # via -r requirements/test.in
-pbr==5.6.0
+pbr==5.7.0
     # via stevedore
-pep517==0.11.0
+pep517==0.12.0
     # via pip-tools
-pip-tools==6.3.0
+pip-tools==6.4.0
     # via -r requirements/dev.in
 pkginfo==1.7.1
     # via twine
@@ -197,15 +192,15 @@ psutil==5.8.0
     # via
     #   edx-django-utils
     #   pact-python
-py==1.10.0
+py==1.11.0
     # via
     #   pytest
     #   tox
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/quality.in
-pycparser==2.20
+pycparser==2.21
     # via cffi
-pycryptodomex==3.10.4
+pycryptodomex==3.11.0
     # via pyjwkest
 pydantic==1.8.2
     # via fastapi
@@ -217,7 +212,7 @@ pygments==2.10.0
     #   readme-renderer
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.3.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
@@ -235,7 +230,7 @@ pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==3.12.0
+pymongo==3.12.1
     # via edx-opaque-keys
 pyparsing==2.4.7
     # via packaging
@@ -257,7 +252,7 @@ pytz==2021.3
     # via
     #   django
     #   fs
-pyyaml==5.4.1
+pyyaml==6.0
     # via code-annotations
 readme-renderer==30.0
     # via twine
@@ -272,14 +267,10 @@ requests==2.26.0
     #   twine
 requests-toolbelt==0.9.1
     # via twine
-responses==0.14.0
+responses==0.15.0
     # via -r requirements/test.in
-rest-condition==1.0.3
-    # via edx-drf-extensions
 rfc3986==1.5.0
     # via twine
-secretstorage==3.3.1
-    # via keyring
 semantic-version==2.8.5
     # via edx-drf-extensions
 six==1.16.0
@@ -294,13 +285,15 @@ six==1.16.0
     #   responses
     #   tox
     #   virtualenv
+sniffio==1.2.0
+    # via anyio
 snowballstemmer==2.1.0
     # via pydocstyle
 sqlparse==0.4.2
     # via django
-starlette==0.14.2
+starlette==0.16.0
     # via fastapi
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   code-annotations
     #   edx-django-utils
@@ -309,12 +302,13 @@ text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via
-    #   coverage
     #   pylint
     #   pytest
     #   tox
-tomli==1.2.1
-    # via pep517
+tomli==1.2.2
+    # via
+    #   coverage
+    #   pep517
 tox==3.24.4
     # via
     #   -r requirements/ci.in
@@ -323,7 +317,7 @@ tox-battery==0.6.1
     # via -r requirements/ci.in
 tqdm==4.62.3
     # via twine
-twine==3.4.2
+twine==3.5.0
     # via -r requirements/quality.in
 typing-extensions==3.10.0.2
     # via
@@ -337,13 +331,13 @@ urllib3==1.26.7
     #   responses
 uvicorn==0.15.0
     # via pact-python
-virtualenv==20.8.1
+virtualenv==20.10.0
     # via tox
 webencodings==0.5.1
     # via bleach
 wheel==0.37.0
     # via pip-tools
-wrapt==1.12.1
+wrapt==1.13.3
     # via astroid
 zipp==3.6.0
     # via importlib-metadata

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.2.4
+pip==21.3.1
     # via -r requirements/pip.in
-setuptools==58.2.0
+setuptools==58.5.3
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,11 +4,13 @@
 #
 #    make upgrade
 #
+anyio==3.3.4
+    # via starlette
 appdirs==1.4.4
     # via fs
 asgiref==3.4.1
     # via uvicorn
-astroid==2.8.0
+astroid==2.8.4
     # via
     #   pylint
     #   pylint-celery
@@ -18,15 +20,15 @@ bleach==4.1.0
     # via readme-renderer
 boto==2.49.0
     # via -r requirements/base.in
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
-cffi==1.14.6
+cffi==1.15.0
     # via cryptography
 chardet==4.0.0
     # via pysrt
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via requests
-click==8.0.1
+click==8.0.3
     # via
     #   click-log
     #   code-annotations
@@ -41,16 +43,15 @@ code-annotations==1.2.0
     #   edx-toggles
 colorama==0.4.4
     # via twine
-coverage[toml]==6.0
+coverage[toml]==6.1.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   django-fernet-fields
     #   pyjwt
-    #   secretstorage
-ddt==1.4.3
+ddt==1.4.4
     # via -r requirements/test.in
 django==2.2.24
     # via
@@ -65,16 +66,15 @@ django==2.2.24
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-    #   rest-condition
 django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-toggles
 django-fernet-fields==0.6
     # via -r requirements/base.in
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via -r requirements/base.in
-django-storages==1.11.1
+django-storages==1.12.3
     # via -r requirements/base.in
 django-waffle==2.2.1
     # via
@@ -85,26 +85,23 @@ djangorestframework==3.12.4
     # via
     #   drf-jwt
     #   edx-drf-extensions
-    #   rest-condition
-docutils==0.17.1
+docutils==0.18
     # via readme-renderer
-drf-jwt==1.19.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   edx-drf-extensions
+drf-jwt==1.19.1
+    # via edx-drf-extensions
 edx-django-utils==4.4.0
     # via
     #   edx-drf-extensions
     #   edx-toggles
-edx-drf-extensions==7.0.1
+edx-drf-extensions==8.0.1
     # via -r requirements/base.in
-edx-lint==5.2.0
+edx-lint==5.2.1
     # via -r requirements/quality.in
 edx-opaque-keys==2.2.2
     # via edx-drf-extensions
 edx-toggles==4.2.0
     # via -r requirements/base.in
-fastapi==0.68.1
+fastapi==0.70.0
     # via pact-python
 fs==2.4.13
     # via -r requirements/test.in
@@ -112,29 +109,27 @@ future==0.18.2
     # via pyjwkest
 h11==0.12.0
     # via uvicorn
-idna==3.2
-    # via requests
-importlib-metadata==4.8.1
+idna==3.3
+    # via
+    #   anyio
+    #   requests
+importlib-metadata==4.8.2
     # via
     #   keyring
     #   twine
 iniconfig==1.1.1
     # via pytest
-isort==5.9.3
+isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jeepney==0.7.1
-    # via
-    #   keyring
-    #   secretstorage
-jinja2==3.0.1
+jinja2==3.0.2
     # via code-annotations
 keyring==23.2.1
     # via twine
 lazy-object-proxy==1.6.0
     # via astroid
-lxml==4.6.3
+lxml==4.6.4
     # via -r requirements/base.in
 markupsafe==2.0.1
     # via jinja2
@@ -142,15 +137,15 @@ mccabe==0.6.1
     # via pylint
 mock==4.0.3
     # via -r requirements/test.in
-newrelic==7.0.0.166
+newrelic==7.2.3.170
     # via edx-django-utils
-packaging==21.0
+packaging==21.2
     # via
     #   bleach
     #   pytest
-pact-python==1.4.4
+pact-python==1.4.5
     # via -r requirements/test.in
-pbr==5.6.0
+pbr==5.7.0
     # via stevedore
 pkginfo==1.7.1
     # via twine
@@ -162,13 +157,13 @@ psutil==5.8.0
     # via
     #   edx-django-utils
     #   pact-python
-py==1.10.0
+py==1.11.0
     # via pytest
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/quality.in
-pycparser==2.20
+pycparser==2.21
     # via cffi
-pycryptodomex==3.10.4
+pycryptodomex==3.11.0
     # via pyjwkest
 pydantic==1.8.2
     # via fastapi
@@ -178,7 +173,7 @@ pygments==2.10.0
     # via readme-renderer
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.3.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
@@ -196,7 +191,7 @@ pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==3.12.0
+pymongo==3.12.1
     # via edx-opaque-keys
 pyparsing==2.4.7
     # via packaging
@@ -218,7 +213,7 @@ pytz==2021.3
     # via
     #   django
     #   fs
-pyyaml==5.4.1
+pyyaml==6.0
     # via code-annotations
 readme-renderer==30.0
     # via twine
@@ -232,14 +227,10 @@ requests==2.26.0
     #   twine
 requests-toolbelt==0.9.1
     # via twine
-responses==0.14.0
+responses==0.15.0
     # via -r requirements/test.in
-rest-condition==1.0.3
-    # via edx-drf-extensions
 rfc3986==1.5.0
     # via twine
-secretstorage==3.3.1
-    # via keyring
 semantic-version==2.8.5
     # via edx-drf-extensions
 six==1.16.0
@@ -252,13 +243,15 @@ six==1.16.0
     #   pyjwkest
     #   python-dateutil
     #   responses
+sniffio==1.2.0
+    # via anyio
 snowballstemmer==2.1.0
     # via pydocstyle
 sqlparse==0.4.2
     # via django
-starlette==0.14.2
+starlette==0.16.0
     # via fastapi
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   code-annotations
     #   edx-django-utils
@@ -269,11 +262,11 @@ toml==0.10.2
     # via
     #   pylint
     #   pytest
-tomli==1.2.1
+tomli==1.2.2
     # via coverage
 tqdm==4.62.3
     # via twine
-twine==3.4.2
+twine==3.5.0
     # via -r requirements/quality.in
 typing-extensions==3.10.0.2
     # via
@@ -289,7 +282,7 @@ uvicorn==0.15.0
     # via pact-python
 webencodings==0.5.1
     # via bleach
-wrapt==1.12.1
+wrapt==1.13.3
     # via astroid
 zipp==3.6.0
     # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+anyio==3.3.4
+    # via starlette
 appdirs==1.4.4
     # via fs
 asgiref==3.4.1
@@ -12,30 +14,30 @@ attrs==21.2.0
     # via pytest
 boto==2.49.0
     # via -r requirements/base.in
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
-cffi==1.14.6
+cffi==1.15.0
     # via cryptography
 chardet==4.0.0
     # via pysrt
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via requests
-click==8.0.1
+click==8.0.3
     # via
     #   code-annotations
     #   pact-python
     #   uvicorn
 code-annotations==1.2.0
     # via edx-toggles
-coverage[toml]==6.0
+coverage[toml]==6.1.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==3.4.8
+cryptography==35.0.0
     # via
     #   django-fernet-fields
     #   pyjwt
-ddt==1.4.3
+ddt==1.4.4
     # via -r requirements/test.in
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -49,16 +51,15 @@ ddt==1.4.3
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-    #   rest-condition
 django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-toggles
 django-fernet-fields==0.6
     # via -r requirements/base.in
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via -r requirements/base.in
-django-storages==1.11.1
+django-storages==1.12.3
     # via -r requirements/base.in
 django-waffle==2.2.1
     # via
@@ -69,22 +70,19 @@ djangorestframework==3.12.4
     # via
     #   drf-jwt
     #   edx-drf-extensions
-    #   rest-condition
-drf-jwt==1.19.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   edx-drf-extensions
+drf-jwt==1.19.1
+    # via edx-drf-extensions
 edx-django-utils==4.4.0
     # via
     #   edx-drf-extensions
     #   edx-toggles
-edx-drf-extensions==7.0.1
+edx-drf-extensions==8.0.1
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via edx-drf-extensions
 edx-toggles==4.2.0
     # via -r requirements/base.in
-fastapi==0.68.1
+fastapi==0.70.0
     # via pact-python
 fs==2.4.13
     # via -r requirements/test.in
@@ -92,25 +90,27 @@ future==0.18.2
     # via pyjwkest
 h11==0.12.0
     # via uvicorn
-idna==3.2
-    # via requests
+idna==3.3
+    # via
+    #   anyio
+    #   requests
 iniconfig==1.1.1
     # via pytest
-jinja2==3.0.1
+jinja2==3.0.2
     # via code-annotations
-lxml==4.6.3
+lxml==4.6.4
     # via -r requirements/base.in
 markupsafe==2.0.1
     # via jinja2
 mock==4.0.3
     # via -r requirements/test.in
-newrelic==7.0.0.166
+newrelic==7.2.3.170
     # via edx-django-utils
-packaging==21.0
+packaging==21.2
     # via pytest
-pact-python==1.4.4
+pact-python==1.4.5
     # via -r requirements/test.in
-pbr==5.6.0
+pbr==5.7.0
     # via stevedore
 pluggy==1.0.0
     # via pytest
@@ -118,21 +118,21 @@ psutil==5.8.0
     # via
     #   edx-django-utils
     #   pact-python
-py==1.10.0
+py==1.11.0
     # via pytest
-pycparser==2.20
+pycparser==2.21
     # via cffi
-pycryptodomex==3.10.4
+pycryptodomex==3.11.0
     # via pyjwkest
 pydantic==1.8.2
     # via fastapi
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.1.0
+pyjwt[crypto]==2.3.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
-pymongo==3.12.0
+pymongo==3.12.1
     # via edx-opaque-keys
 pyparsing==2.4.7
     # via packaging
@@ -154,7 +154,7 @@ pytz==2021.3
     # via
     #   django
     #   fs
-pyyaml==5.4.1
+pyyaml==6.0
     # via code-annotations
 requests==2.26.0
     # via
@@ -162,10 +162,8 @@ requests==2.26.0
     #   pact-python
     #   pyjwkest
     #   responses
-responses==0.14.0
+responses==0.15.0
     # via -r requirements/test.in
-rest-condition==1.0.3
-    # via edx-drf-extensions
 semantic-version==2.8.5
     # via edx-drf-extensions
 six==1.16.0
@@ -176,11 +174,13 @@ six==1.16.0
     #   pyjwkest
     #   python-dateutil
     #   responses
+sniffio==1.2.0
+    # via anyio
 sqlparse==0.4.2
     # via django
-starlette==0.14.2
+starlette==0.16.0
     # via fastapi
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   code-annotations
     #   edx-django-utils
@@ -189,7 +189,7 @@ text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via pytest
-tomli==1.2.1
+tomli==1.2.2
     # via coverage
 typing-extensions==3.10.0.2
     # via pydantic


### PR DESCRIPTION
[PROD-2552](https://openedx.atlassian.net/browse/PROD-2552)

Adds a separate pact provider verification job in CI. The pacts are retrieved from pactflow, verification is performed and after that, the results are published with dev/prod tags and provider version.
Also, we're allowing [Pending Pacts](https://docs.pact.io/pact_broker/advanced_topics/pending_pacts/) in edx-val as not doing that may block the edxval from merging the new changes if one or more consumers pacts are failing (even when the provider is compatible with the deployed version of the consumer)