### PR TITLE
fix: use master/production on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,17 @@ jobs:
 
     - name: Verify Pacts
       run: |
+        export IS_MERGED=${{ github.event.pull_request.merged }}
         export PACT_BROKER_BASE_URL='https://edx.pactflow.io'
         export PACT_BROKER_TOKEN=${{ secrets.PACT_FLOW_ACCESS_TOKEN }}
         export PUBLISH_VERSION=`git rev-parse --short HEAD`
-        export PUBLISH_TAGS=${{ github.head_ref }}
+        if [ $IS_MERGED == false ]
+        then
+          export PUBLISH_TAGS=$GITHUB_HEAD_REF
+          export GIT_ENV='development'
+        else
+          export PUBLISH_TAGS=${GITHUB_REF:11}
+          export GIT_ENV='production'
+        fi
         export PUBLISH_VERIFICATION_RESULTS=true
         pytest -s edxval/pacts/verify_pact.py --ds=edxval.settings.pact

--- a/edxval/pacts/verify_pact.py
+++ b/edxval/pacts/verify_pact.py
@@ -24,7 +24,7 @@ class ProviderVerificationServer(LiveServerTestCase):
             {"tag": "master", "latest": True},
         ],
         'publish_version': settings.PUBLISH_VERSION,
-        'provider_tags': settings.PUBLISH_TAGS,
+        'provider_tags': [settings.PUBLISH_TAGS, settings.GIT_ENV],
         'publish_verification_results': settings.PUBLISH_VERIFICATION_RESULTS,
         'headers': ['Pact-Authentication: AllowAny', ],
     }

--- a/edxval/settings/pact.py
+++ b/edxval/settings/pact.py
@@ -13,6 +13,6 @@ PROVIDER_STATES_SETUP_VIEW_URL = True
 PACT_BROKER_BASE_URL = os.environ.get('PACT_BROKER_BASE_URL', 'http://localhost:9292')
 PUBLISH_VERSION = os.environ.get('PUBLISH_VERSION', '1')
 PUBLISH_TAGS = os.environ.get('PUBLISH_TAGS', 'master')
-PUBLISH_TAGS = [PUBLISH_TAGS, 'production' if PUBLISH_TAGS == 'master' else 'development']
+GIT_ENV = os.environ.get('GIT_ENV')
 
 MIDDLEWARE = MIDDLEWARE + ('edxval.pacts.middleware.AuthenticationMiddleware',)


### PR DESCRIPTION

The [previous job merge job](https://github.com/edx/edx-val/runs/4162168998?check_suite_focus=true) failed due to `github.head_ref` not giving `master` on merge.

Using the same method as we did in [VEM](https://github.com/edx/video-encode-manager/pull/291) using github.ref on merge action gives you the branch name.