### PR TITLE
build: remove broker base env variable to avoid extra pact verifications

### DIFF
--- a/.github/workflows/verify_changed_contract.yml
+++ b/.github/workflows/verify_changed_contract.yml
@@ -8,7 +8,6 @@ on:
 env:
   CHANGED_PACT_URL: ${{ github.event.client_payload.pact_url }}
   GIT_ENV: Production
-  PACT_BROKER_BASE_URL: https://edx.pactflow.io
   PACT_BROKER_TOKEN: ${{ secrets.PACT_FLOW_ACCESS_TOKEN }}
   PUBLISH_VERIFICATION_RESULTS: true
   VERIFY_WITH_BROKER: false


### PR DESCRIPTION
### [PROD-2576](https://openedx.atlassian.net/browse/PROD-2576)

### Description

Remove broker url environment variable from contract changed CI to avoid the extra pact verifications. The broker base url environment setting results in verifier fetching additional pact along with the pact defined via changed url pact([Build](https://github.com/edx/edx-val/runs/4296436358?check_suite_focus=true)). This happens because pact verifier internally fetches the pacts from broker if provider name and broker url are defined([Ref](https://github.com/pact-foundation/pact-provider-verifier/blob/master/lib/pact/provider_verifier/aggregate_pact_configs.rb#L37)). The environment variable is not required when attempting verification against a single pact via url(See [description](https://github.com/pact-foundation/pact-provider-verifier#usage)).